### PR TITLE
Add Perl 5.22!

### DIFF
--- a/5.022.000-64bit,threaded/DevelPatchPerl.patch
+++ b/5.022.000-64bit,threaded/DevelPatchPerl.patch
@@ -1,0 +1,12 @@
+diff --git a/patchlevel.h b/patchlevel.h
+index a0ad78b..1812032 100644
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -137,6 +137,7 @@ static const char * const local_patches[] = {
+ 	,"uncommitted-changes"
+ #endif
+ 	PERL_GIT_UNPUSHED_COMMITS    	/* do not remove this line */
++	,"Devel::PatchPerl 1.34"
+ 	,NULL
+ };
+ 

--- a/5.022.000-64bit,threaded/Dockerfile
+++ b/5.022.000-64bit,threaded/Dockerfile
@@ -1,0 +1,29 @@
+FROM buildpack-deps
+MAINTAINER Peter Martini <PeterCMartini@GMail.com>
+
+RUN apt-get update \
+    && apt-get install -y curl procps \
+    && rm -fr /var/lib/apt/lists/*
+
+RUN mkdir /usr/src/perl
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.22.0.tar.bz2 -o perl-5.22.0.tar.bz2 \
+    && echo '400338c91c56420d98142cbfcb84d418cae2c98c *perl-5.22.0.tar.bz2' | sha1sum -c - \
+    && tar --strip-components=1 -xjf perl-5.22.0.tar.bz2 -C /usr/src/perl \
+    && rm perl-5.22.0.tar.bz2 \
+    && cat *.patch | patch -p1 \
+    && ./Configure -Dusethreads -Duse64bitall  -des \
+    && make -j$(nproc) \
+    && make test_harness \
+    && make install \
+    && cd /usr/src \
+    && curl -LO https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm \
+    && chmod +x cpanm \
+    && ./cpanm App::cpanminus \
+    && rm -fr ./cpanm /root/.cpanm /usr/src/perl
+
+WORKDIR /root
+
+CMD ["perl5.22.0","-de0"]

--- a/5.022.000-64bit/DevelPatchPerl.patch
+++ b/5.022.000-64bit/DevelPatchPerl.patch
@@ -1,0 +1,12 @@
+diff --git a/patchlevel.h b/patchlevel.h
+index a0ad78b..1812032 100644
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -137,6 +137,7 @@ static const char * const local_patches[] = {
+ 	,"uncommitted-changes"
+ #endif
+ 	PERL_GIT_UNPUSHED_COMMITS    	/* do not remove this line */
++	,"Devel::PatchPerl 1.34"
+ 	,NULL
+ };
+ 

--- a/5.022.000-64bit/Dockerfile
+++ b/5.022.000-64bit/Dockerfile
@@ -1,0 +1,29 @@
+FROM buildpack-deps
+MAINTAINER Peter Martini <PeterCMartini@GMail.com>
+
+RUN apt-get update \
+    && apt-get install -y curl procps \
+    && rm -fr /var/lib/apt/lists/*
+
+RUN mkdir /usr/src/perl
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.22.0.tar.bz2 -o perl-5.22.0.tar.bz2 \
+    && echo '400338c91c56420d98142cbfcb84d418cae2c98c *perl-5.22.0.tar.bz2' | sha1sum -c - \
+    && tar --strip-components=1 -xjf perl-5.22.0.tar.bz2 -C /usr/src/perl \
+    && rm perl-5.22.0.tar.bz2 \
+    && cat *.patch | patch -p1 \
+    && ./Configure -Duse64bitall  -des \
+    && make -j$(nproc) \
+    && make test_harness \
+    && make install \
+    && cd /usr/src \
+    && curl -LO https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm \
+    && chmod +x cpanm \
+    && ./cpanm App::cpanminus \
+    && rm -fr ./cpanm /root/.cpanm /usr/src/perl
+
+WORKDIR /root
+
+CMD ["perl5.22.0","-de0"]

--- a/Releases.yaml
+++ b/Releases.yaml
@@ -39,3 +39,8 @@ releases:
     sha1:    63126c683b4c79c35008a47d56f7beae876c569f
     pause:   SHAY
     test_parallel: no
+
+  - version: 5.22.0
+    sha1:    400338c91c56420d98142cbfcb84d418cae2c98c
+    pause:   RJBS
+    test_parallel: no


### PR DESCRIPTION
I didn't know whether to include the useless `.patch` files that were generated -- I'm happy to rebase to not include them.

It looks like `generate.pl` is also wanting to bump the `Devel::PatchPerl` version number in all the older versions, which I ignored. :smile: