### PR TITLE
Add -Duseshrplib to build flags to build a shared libperl.so

### DIFF
--- a/generate.pl
+++ b/generate.pl
@@ -37,8 +37,8 @@ my $template = do {
 };
 
 my %builds = (
-  "64bit"          => "-Duse64bitall",
-  "64bit,threaded" => "-Dusethreads -Duse64bitall",
+  "64bit"          => "-Duse64bitall -Duseshrplib",
+  "64bit,threaded" => "-Dusethreads -Duse64bitall -Duseshrplib",
 );
 
 die_with_sample unless defined $yaml->{releases};


### PR DESCRIPTION
Perl's ./Configure can be asked to build a shared library, libperl.so,
which is required by some modules from CPAN (like Imagemagick), or when
you want to embed the Perl interpreter in your own programs.

However, because there may be a performance penalty, the "old" static
builds have not been removed.

More information can be found in the installation manual at
https://metacpan.org/pod/distribution/perl/INSTALL#Building-a-shared-Perl-library