### PR TITLE
Add alpine variants (templated)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,3 +1,11 @@
+# CI matrix is auto-generated from any directory containing a Dockerfile via
+# `dirname */Dockerfile`. Adding a new variant directory (debian or alpine)
+# requires no edits here — the matrix picks it up on the next push.
+#
+# The slim-gating logic in the cpanm/cpm/Net::DNS test steps (predicated on
+# `[[ "$dir" == *"slim"* ]]`) correctly skips slim variants and includes
+# alpine variants (alpine retains the full build toolchain at runtime,
+# parallel to debian-main).
 name: Build and Test
 
 on:
@@ -5,7 +13,7 @@ on:
     paths:
       - '**/Dockerfile'
       - '!.devcontainer/Dockerfile'
-      - '**/DevelPatchPerl.patch'
+      - '**/*.patch'
 
 defaults:
   run:
@@ -31,6 +39,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     name: ${{ matrix.directory }}
 
@@ -82,7 +91,7 @@ jobs:
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           if [[ "$dir" != *"slim"* ]]; then
-            docker run "$img" bash -c "cpanm -v -n LWP && cpanm -v -n local::lib"
+            docker run "$img" sh -c "cpanm -v -n LWP && cpanm -v -n local::lib"
           fi
 
       - name: Run cpm install test

--- a/.github/workflows/generate-dockerfiles-patches.yml
+++ b/.github/workflows/generate-dockerfiles-patches.yml
@@ -11,6 +11,11 @@ on:
       - cpanfile
       - config.yml
       - generate.pl
+      - library.pl
+      - Dockerfile.alpine.template
+      - Dockerfile.debian.template
+      - musl-stack-size.patch
+      - t/**
       - .github/workflows/generate-dockerfiles-patches.yml
 
 jobs:
@@ -38,19 +43,27 @@ jobs:
         run: |
           export DOCKER_PERL_DOWNLOADS_DIR=/tmp/docker-perl-downloads
           perl ./generate.pl
-          /usr/bin/git --no-pager diff --stat > diffstat.txt
-          if [[ -s diffstat.txt ]]; then
+          /usr/bin/git --no-pager diff --stat > /tmp/diffstat.txt
+          /usr/bin/git status --porcelain > /tmp/status.txt
+          if [[ -s /tmp/diffstat.txt || -s /tmp/status.txt ]]; then
             echo has_extra_diffs=1 >> $GITHUB_OUTPUT
           fi
 
       - name: Fail if there are extra diffs
         if: steps.generate.outputs.has_extra_diffs
         run: |
-          echo "::error title=generate::Extra diffs found during generate"
-          echo "Additional changes found during generate - check diffstat below:"
-          echo "::group::diffstat"
-          cat diffstat.txt
+          echo "::error title=generate::Extra diffs or untracked files found during generate"
+          echo "Additional changes found during generate. Committed content must match a fresh generate.pl run exactly, including new files. Check below:"
+          echo "::group::diffstat (modified tracked files)"
+          cat /tmp/diffstat.txt
+          echo "::endgroup::"
+          echo "::group::status (untracked/uncommitted files, e.g. missing git add)"
+          cat /tmp/status.txt
           echo "::endgroup::"
           echo
 
           exit 1
+
+      - name: Run alpine regression checks
+        run: |
+          prove -v t/*.t

--- a/5.040.005-main,threaded-alpine3.23/DevelPatchPerl.patch
+++ b/5.040.005-main,threaded-alpine3.23/DevelPatchPerl.patch
@@ -1,0 +1,15 @@
+diff --git a/hints/linux.sh b/hints/linux.sh
+index 83ba0c5..d5a7f25 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -486,3 +486,10 @@ case "$libdb_needs_pthread" in
+     libswanted="$libswanted pthread"
+     ;;
+ esac
++
++# Detect case-insensitive file systems
++echo X >UU/casesense.tmp
++if test -f UU/CASESENSE.TMP && test -f UU/CaSeSeNsE.tMp; then
++    firstmakefile='GNUmakefile'
++fi
++rm -f UU/casesense.tmp

--- a/5.040.005-main,threaded-alpine3.23/Dockerfile
+++ b/5.040.005-main,threaded-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.40.5.tar.gz -o perl-5.40.5.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '09d926ae2d1b277c3bce62054c41da47c981380d719c41cf980b67945cc581ed *perl-5.40.5.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.40.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.40.5.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.40.5","-de0"]

--- a/5.040.005-main,threaded-alpine3.23/musl-stack-size.patch
+++ b/5.040.005-main,threaded-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.040.005-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.040.005-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.040.005-main,threaded-alpine3.24/DevelPatchPerl.patch
+++ b/5.040.005-main,threaded-alpine3.24/DevelPatchPerl.patch
@@ -1,0 +1,15 @@
+diff --git a/hints/linux.sh b/hints/linux.sh
+index 83ba0c5..d5a7f25 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -486,3 +486,10 @@ case "$libdb_needs_pthread" in
+     libswanted="$libswanted pthread"
+     ;;
+ esac
++
++# Detect case-insensitive file systems
++echo X >UU/casesense.tmp
++if test -f UU/CASESENSE.TMP && test -f UU/CaSeSeNsE.tMp; then
++    firstmakefile='GNUmakefile'
++fi
++rm -f UU/casesense.tmp

--- a/5.040.005-main,threaded-alpine3.24/Dockerfile
+++ b/5.040.005-main,threaded-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.40.5.tar.gz -o perl-5.40.5.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '09d926ae2d1b277c3bce62054c41da47c981380d719c41cf980b67945cc581ed *perl-5.40.5.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.40.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.40.5.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.40.5","-de0"]

--- a/5.040.005-main,threaded-alpine3.24/musl-stack-size.patch
+++ b/5.040.005-main,threaded-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.040.005-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.040.005-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.040.005-main-alpine3.23/DevelPatchPerl.patch
+++ b/5.040.005-main-alpine3.23/DevelPatchPerl.patch
@@ -1,0 +1,15 @@
+diff --git a/hints/linux.sh b/hints/linux.sh
+index 83ba0c5..d5a7f25 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -486,3 +486,10 @@ case "$libdb_needs_pthread" in
+     libswanted="$libswanted pthread"
+     ;;
+ esac
++
++# Detect case-insensitive file systems
++echo X >UU/casesense.tmp
++if test -f UU/CASESENSE.TMP && test -f UU/CaSeSeNsE.tMp; then
++    firstmakefile='GNUmakefile'
++fi
++rm -f UU/casesense.tmp

--- a/5.040.005-main-alpine3.23/Dockerfile
+++ b/5.040.005-main-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.40.5.tar.gz -o perl-5.40.5.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '09d926ae2d1b277c3bce62054c41da47c981380d719c41cf980b67945cc581ed *perl-5.40.5.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.40.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.40.5.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.40.5","-de0"]

--- a/5.040.005-main-alpine3.23/musl-stack-size.patch
+++ b/5.040.005-main-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.040.005-main-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.040.005-main-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.040.005-main-alpine3.24/DevelPatchPerl.patch
+++ b/5.040.005-main-alpine3.24/DevelPatchPerl.patch
@@ -1,0 +1,15 @@
+diff --git a/hints/linux.sh b/hints/linux.sh
+index 83ba0c5..d5a7f25 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -486,3 +486,10 @@ case "$libdb_needs_pthread" in
+     libswanted="$libswanted pthread"
+     ;;
+ esac
++
++# Detect case-insensitive file systems
++echo X >UU/casesense.tmp
++if test -f UU/CASESENSE.TMP && test -f UU/CaSeSeNsE.tMp; then
++    firstmakefile='GNUmakefile'
++fi
++rm -f UU/casesense.tmp

--- a/5.040.005-main-alpine3.24/Dockerfile
+++ b/5.040.005-main-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.40.5.tar.gz -o perl-5.40.5.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '09d926ae2d1b277c3bce62054c41da47c981380d719c41cf980b67945cc581ed *perl-5.40.5.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.40.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.40.5.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.40.5","-de0"]

--- a/5.040.005-main-alpine3.24/musl-stack-size.patch
+++ b/5.040.005-main-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.040.005-main-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.040.005-main-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.042.003-main,threaded-alpine3.23/Dockerfile
+++ b/5.042.003-main,threaded-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.42.3.tar.gz -o perl-5.42.3.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '1137740985837b5cdf15f0cfab932279dcb4352f912fed6fc144e8b4f0823627 *perl-5.42.3.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.42.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.42.3.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.42.3","-de0"]

--- a/5.042.003-main,threaded-alpine3.23/musl-stack-size.patch
+++ b/5.042.003-main,threaded-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.042.003-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.042.003-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.042.003-main,threaded-alpine3.24/Dockerfile
+++ b/5.042.003-main,threaded-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.42.3.tar.gz -o perl-5.42.3.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '1137740985837b5cdf15f0cfab932279dcb4352f912fed6fc144e8b4f0823627 *perl-5.42.3.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.42.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.42.3.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.42.3","-de0"]

--- a/5.042.003-main,threaded-alpine3.24/musl-stack-size.patch
+++ b/5.042.003-main,threaded-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.042.003-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.042.003-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.042.003-main-alpine3.23/Dockerfile
+++ b/5.042.003-main-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.42.3.tar.gz -o perl-5.42.3.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '1137740985837b5cdf15f0cfab932279dcb4352f912fed6fc144e8b4f0823627 *perl-5.42.3.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.42.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.42.3.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.42.3","-de0"]

--- a/5.042.003-main-alpine3.23/musl-stack-size.patch
+++ b/5.042.003-main-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.042.003-main-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.042.003-main-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.042.003-main-alpine3.24/Dockerfile
+++ b/5.042.003-main-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.42.3.tar.gz -o perl-5.42.3.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '1137740985837b5cdf15f0cfab932279dcb4352f912fed6fc144e8b4f0823627 *perl-5.42.3.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.42.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.42.3.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.42.3","-de0"]

--- a/5.042.003-main-alpine3.24/musl-stack-size.patch
+++ b/5.042.003-main-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.042.003-main-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.042.003-main-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 49e39b7..289c9da 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -405,7 +405,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.044.000-main,threaded-alpine3.23/Dockerfile
+++ b/5.044.000-main,threaded-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/L/LE/LEONT/perl-5.44.0.tar.gz -o perl-5.44.0.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3 *perl-5.44.0.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.44.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.44.0.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.44.0","-de0"]

--- a/5.044.000-main,threaded-alpine3.23/musl-stack-size.patch
+++ b/5.044.000-main,threaded-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.044.000-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.044.000-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.044.000-main,threaded-alpine3.24/Dockerfile
+++ b/5.044.000-main,threaded-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/L/LE/LEONT/perl-5.44.0.tar.gz -o perl-5.44.0.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3 *perl-5.44.0.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.44.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.44.0.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.44.0","-de0"]

--- a/5.044.000-main,threaded-alpine3.24/musl-stack-size.patch
+++ b/5.044.000-main,threaded-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.044.000-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.044.000-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.044.000-main-alpine3.23/Dockerfile
+++ b/5.044.000-main-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/L/LE/LEONT/perl-5.44.0.tar.gz -o perl-5.44.0.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3 *perl-5.44.0.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.44.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.44.0.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.44.0","-de0"]

--- a/5.044.000-main-alpine3.23/musl-stack-size.patch
+++ b/5.044.000-main-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.044.000-main-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.044.000-main-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.044.000-main-alpine3.24/Dockerfile
+++ b/5.044.000-main-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/L/LE/LEONT/perl-5.44.0.tar.gz -o perl-5.44.0.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3 *perl-5.44.0.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.44.0.tar.gz -C /usr/src/perl \
+    && rm perl-5.44.0.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.44.0","-de0"]

--- a/5.044.000-main-alpine3.24/musl-stack-size.patch
+++ b/5.044.000-main-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.044.000-main-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.044.000-main-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.045.001-main,threaded-alpine3.23/Dockerfile
+++ b/5.045.001-main,threaded-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.45.1.tar.gz -o perl-5.45.1.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '2b6d691916596835c411ee0181b6c66e4ee1c8d6ab60f8b0733c7c9cf8b58e3e *perl-5.45.1.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.45.1.tar.gz -C /usr/src/perl \
+    && rm perl-5.45.1.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -Dusedevel -Dversiononly=undef -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.45.1","-de0"]

--- a/5.045.001-main,threaded-alpine3.23/musl-stack-size.patch
+++ b/5.045.001-main,threaded-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.045.001-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.045.001-main,threaded-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.045.001-main,threaded-alpine3.24/Dockerfile
+++ b/5.045.001-main,threaded-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.45.1.tar.gz -o perl-5.45.1.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '2b6d691916596835c411ee0181b6c66e4ee1c8d6ab60f8b0733c7c9cf8b58e3e *perl-5.45.1.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.45.1.tar.gz -C /usr/src/perl \
+    && rm perl-5.45.1.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -Dusedevel -Dversiononly=undef -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.45.1","-de0"]

--- a/5.045.001-main,threaded-alpine3.24/musl-stack-size.patch
+++ b/5.045.001-main,threaded-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.045.001-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.045.001-main,threaded-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.045.001-main-alpine3.23/Dockerfile
+++ b/5.045.001-main-alpine3.23/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.23
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.45.1.tar.gz -o perl-5.45.1.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '2b6d691916596835c411ee0181b6c66e4ee1c8d6ab60f8b0733c7c9cf8b58e3e *perl-5.45.1.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.45.1.tar.gz -C /usr/src/perl \
+    && rm perl-5.45.1.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -Dusedevel -Dversiononly=undef -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.45.1","-de0"]

--- a/5.045.001-main-alpine3.23/musl-stack-size.patch
+++ b/5.045.001-main-alpine3.23/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.045.001-main-alpine3.23/skip-test-due-to-busybox-ps.patch
+++ b/5.045.001-main-alpine3.23/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/5.045.001-main-alpine3.24/Dockerfile
+++ b/5.045.001-main-alpine3.24/Dockerfile
@@ -1,0 +1,71 @@
+FROM alpine:3.24
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+COPY *.patch /usr/src/perl/
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        patch \
+        procps \
+        tar \
+        xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.45.1.tar.gz -o perl-5.45.1.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
+    && echo '2b6d691916596835c411ee0181b6c66e4ee1c8d6ab60f8b0733c7c9cf8b58e3e *perl-5.45.1.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-5.45.1.tar.gz -C /usr/src/perl \
+    && rm perl-5.45.1.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -Dusedevel -Dversiononly=undef -des \
+    && make -j$(nproc) \
+    && TEST_JOBS=$(nproc) make test_harness_notty \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7049.tar.gz \
+    && echo 'b9ffb88e62a06aa91bd7d5a28ef6bdbb942608aea90e3969aa29b33640035214 *App-cpanminus-1.7049.tar.gz' | sha256sum -c - \
+    && tar -xzf App-cpanminus-1.7049.tar.gz && cd App-cpanminus-1.7049 \
+    && perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm \
+    && perl -pi -E 's{try_lwp=>1}{try_lwp=>0}g' bin/cpanm \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO 'https://www.cpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz' \
+    && echo 'ab213691685fb2a576c669cbc8d9266f8165a31563ad15b7c4030b94adfc0753 *Net-SSLeay-1.96.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD Net-SSLeay-1.96.tar.gz \
+    && curl -fLO 'https://www.cpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.099.tar.gz' \
+    && echo 'a0be800ff4852b1567ee5500e772417ad7a360abff80c01b5b875c15d44be832 *IO-Socket-SSL-2.099.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD IO-Socket-SSL-2.099.tar.gz \
+    && curl -fL https://raw.githubusercontent.com/skaji/cpm/v1.1.4/cpm -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '6f5ae6d0e25ba20f768b8856ea61481da9d142a04629d658025011c76d3bbc3f */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/Net-SSLeay-1.96* /root/IO-Socket-SSL-2.099* /usr/src/perl /usr/src/App-cpanminus-1.7049* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl5.45.1","-de0"]

--- a/5.045.001-main-alpine3.24/musl-stack-size.patch
+++ b/5.045.001-main-alpine3.24/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/5.045.001-main-alpine3.24/skip-test-due-to-busybox-ps.patch
+++ b/5.045.001-main-alpine3.24/skip-test-due-to-busybox-ps.patch
@@ -1,0 +1,13 @@
+diff --git a/t/op/magic.t b/t/op/magic.t
+index 929a746..dff2561 100644
+--- a/t/op/magic.t
++++ b/t/op/magic.t
+@@ -406,7 +406,7 @@ EOP
+ # argv[0] assignment and by calling prctl()
+ {
+   SKIP: {
+-    skip "We don't have prctl() here, or we're on Android", 2 unless $Config{d_prctl_set_name} && $^O ne 'android';
++    skip "Skip test to avoid external ps(1) dependency", 2;
+ 
+     # We don't really need these tests. prctl() is tested in the
+     # Kernel, but test it anyway for our sanity. If something doesn't

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -23,18 +23,16 @@ RUN set -eux \
         openssl-dev \
         pkgconf \
         tzdata \
-        wget \
         zlib-dev \
     && apk add --no-cache --virtual .build-deps \
         dpkg \
         dpkg-dev \
-        gnupg \
         patch \
-        pax-utils \
         procps \
         tar \
         xz \
     && curl -fL {{url}} -o perl-{{version}}.tar.gz \
+    # busybox sha256sum does not support --strict; -c alone is sufficient here
     && echo '{{sha256}} *perl-{{version}}.tar.gz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-{{version}}.tar.gz -C /usr/src/perl \
     && rm perl-{{version}}.tar.gz \
@@ -52,6 +50,7 @@ RUN set -eux \
     && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} \
     && {{cpanm_dist_patch_https}} \
     && {{cpanm_dist_patch_nolwp}} \
+    && perl -pi -E 's{try_wget=>1}{try_wget=>0}g' bin/cpanm \
     && perl bin/cpanm . && cd /root \
     && curl -fLO '{{netssleay_dist_url}}' \
     && echo '{{netssleay_dist_sha256}} *{{netssleay_dist_name}}.tar.gz' | sha256sum -c - \

--- a/Dockerfile.alpine.template
+++ b/Dockerfile.alpine.template
@@ -1,0 +1,72 @@
+FROM alpine:{{alpine_tag_short}}
+
+# This image deliberately retains the build toolchain at runtime (parallel
+# to debian-main's buildpack-deps-based image), so cpanm/cpm installs of
+# XS modules Just Work. This diverges from python:3-alpine / ruby:3-alpine
+# which strip everything via scanelf-based runDeps pruning. Two virtual
+# package sets: a permanent keeper, and a transient `.build-deps` purged
+# at the end.
+
+{{docker_copy_perl_patch}}
+WORKDIR /usr/src/perl
+
+RUN set -eux \
+    && apk add --no-cache \
+        build-base \
+        bzip2-dev \
+        ca-certificates \
+        curl \
+        libc-dev \
+        linux-headers \
+        make \
+        openssl \
+        openssl-dev \
+        pkgconf \
+        tzdata \
+        wget \
+        zlib-dev \
+    && apk add --no-cache --virtual .build-deps \
+        dpkg \
+        dpkg-dev \
+        gnupg \
+        patch \
+        pax-utils \
+        procps \
+        tar \
+        xz \
+    && curl -fL {{url}} -o perl-{{version}}.tar.gz \
+    && echo '{{sha256}} *perl-{{version}}.tar.gz' | sha256sum -c - \
+    && tar --strip-components=1 -xaf perl-{{version}}.tar.gz -C /usr/src/perl \
+    && rm perl-{{version}}.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" {{args}} {{extra_flags}} -des \
+    && make -j$(nproc) \
+    && {{test_alpine}} \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO {{cpanm_dist_url}} \
+    && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum -c - \
+    && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} \
+    && {{cpanm_dist_patch_https}} \
+    && {{cpanm_dist_patch_nolwp}} \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO '{{netssleay_dist_url}}' \
+    && echo '{{netssleay_dist_sha256}} *{{netssleay_dist_name}}.tar.gz' | sha256sum -c - \
+    && cpanm --notest --from $PWD {{netssleay_dist_name}}.tar.gz \
+    && curl -fLO '{{iosocketssl_dist_url}}' \
+    && echo '{{iosocketssl_dist_sha256}} *{{iosocketssl_dist_name}}.tar.gz' | sha256sum -c - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --notest --from $PWD {{iosocketssl_dist_name}}.tar.gz \
+    && curl -fL {{cpm_dist_url}} -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '{{cpm_dist_sha256}} */usr/local/bin/cpm' | sha256sum -c - \
+    && chmod +x /usr/local/bin/cpm \
+    && apk del --no-network .build-deps \
+    && rm -fr /root/.cpanm /root/{{netssleay_dist_name}}* /root/{{iosocketssl_dist_name}}* /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl{{version}}","-de0"]

--- a/Dockerfile.debian.template
+++ b/Dockerfile.debian.template
@@ -1,0 +1,42 @@
+FROM {{image}}:{{tag}}
+
+{{docker_copy_perl_patch}}
+WORKDIR /usr/src/perl
+
+RUN {{docker_slim_run_install}} \
+    && curl -fL {{url}} -o perl-{{version}}.tar.gz \
+    && echo '{{sha256}} *perl-{{version}}.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-{{version}}.tar.gz -C /usr/src/perl \
+    && rm perl-{{version}}.tar.gz \
+    && cat *.patch | patch -p1 \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" {{args}} {{extra_flags}} -des \
+    && make -j$(nproc) \
+    && {{test}} \
+    && make install \
+    && cd /usr/src \
+    && curl -fLO {{cpanm_dist_url}} \
+    && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum --strict --check - \
+    && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} \
+    && {{cpanm_dist_patch_https}} \
+    && {{cpanm_dist_patch_nolwp}} \
+    && perl bin/cpanm . && cd /root \
+    && curl -fLO '{{netssleay_dist_url}}' \
+    && echo '{{netssleay_dist_sha256}} *{{netssleay_dist_name}}.tar.gz' | sha256sum --strict --check - \
+    && cpanm --notest --from $PWD {{netssleay_dist_name}}.tar.gz \
+    && curl -fLO '{{iosocketssl_dist_url}}' \
+    && echo '{{iosocketssl_dist_sha256}} *{{iosocketssl_dist_name}}.tar.gz' | sha256sum --strict --check - \
+    && SSL_CERT_DIR=/etc/ssl/certs cpanm --from $PWD {{iosocketssl_dist_name}}.tar.gz \
+    && curl -fL {{cpm_dist_url}} -o /usr/local/bin/cpm \
+    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
+    && echo '{{cpm_dist_sha256}} */usr/local/bin/cpm' | sha256sum --strict --check - \
+    && chmod +x /usr/local/bin/cpm \
+    && {{docker_slim_run_purge}} \
+    && rm -fr /root/.cpanm /root/{{netssleay_dist_name}}* /root/{{iosocketssl_dist_name}}* /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/* \
+    && cpanm --version && cpm --version
+
+WORKDIR /usr/src/app
+
+CMD ["perl{{version}}","-de0"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,60 @@ locally applied patches.  These changes should be limited to Configure
 rather than to code itself, and will be a cherry pick or back port of a
 patch from the mainline perl branch whenever possible.
 
+The `t/` directory holds regression checks for the generated
+Dockerfiles, run with `prove -r t/`.  These read the generated files,
+so run `./generate.pl` first.  By default only static checks run;
+setting `RUN_RUNTIME=1` additionally runs `docker run` assertions in
+`t/alpine-checks.t` against already-built `perl:<tag>` images, which
+are skipped otherwise.
+
+## Alpine Variants
+
+From Perl 5.40 onwards, `perl` is also published in Alpine Linux variants
+alongside the existing Debian-based ones. These follow the same template-driven
+generation through `generate.pl` and share the same Net::SSLeay / IO::Socket::SSL
+/ cpanm / cpm tooling as the Debian `main` variants.
+
+**Published tags** (per supported Perl version, `<version>`):
+
+| Tag | Base | Threading |
+|---|---|---|
+| `<version>-alpine` (rolling, aliases current stable) | alpine:3.24 | non-threaded |
+| `<version>-threaded-alpine` (rolling) | alpine:3.24 | threaded |
+| `<version>-alpine3.24` (pinned, current stable) | alpine:3.24 | non-threaded |
+| `<version>-threaded-alpine3.24` (pinned) | alpine:3.24 | threaded |
+| `<version>-alpine3.23` (pinned, previous stable) | alpine:3.23 | non-threaded |
+| `<version>-threaded-alpine3.23` (pinned) | alpine:3.23 | threaded |
+
+Two alpine versions ship per Perl release: current stable and previous stable,
+mirroring the cadence of `python:3-alpine` and `ruby:3-alpine`.
+
+### Caveats
+
+* **No `-slim` on alpine.** Alpine is already minimal, there is no separate
+  `slim-alpine` variant. Use `perl:<version>-slim-<debian-tag>` for the
+  smallest official images.
+* **Alpine uses musl libc.** For the vast majority of Pure Perl and well-behaved
+  XS modules, this is transparent. Quirks users may occasionally encounter:
+  * `setlocale()` and locale handling work but may differ from glibc in edge
+    cases (musl's locale support is functional but not full-fat).
+  * Threaded Perl on musl: all alpine images ship a musl stack-size patch
+    (256k floor) that works around upstream
+    [perl5#18160](https://github.com/Perl/perl5/issues/18160).
+* **Build toolchain retained at runtime.** Unlike `python:3-alpine` and
+  `ruby:3-alpine` which strip the compiler after build, these images keep
+  `build-base`, `make`, `openssl-dev`, and friends so `cpanm` / `cpm`
+  installs of XS modules work out of the box, parallel to debian-main's
+  `buildpack-deps`-based image.
+* **`tzdata` pre-installed.** Unlike many Alpine images, `tzdata` is
+  permanently installed so timezone-aware Perl applications work without
+  any extra setup.
+* **Default shell is busybox `sh`, not bash.** `RUN` steps using
+  bash-specific syntax (`[[ ]]`, `source`, process substitution) will
+  fail. Write portable POSIX shell in `RUN` steps, or add
+  `apk add bash` and use `SHELL ["/bin/bash", "-c"]`.
+
 ## See Also
 
 * [Docker Library FAQ](https://github.com/docker-library/faq?tab=readme-ov-file#what-do-you-mean-by-official)
-* 
+

--- a/config.yml
+++ b/config.yml
@@ -7,32 +7,46 @@ options:
   common: "-Duseshrplib -Dvendorprefix=/usr/local"
   threaded: "-Dusethreads"
 
+# Per-OS-family build restrictions. When a family appears here, only the
+# listed builds are emitted for entries with that family. Default (key
+# absent) = all builds apply. Empty list (e.g. `foo: []`) = skip entirely.
+build_constraints:
+  alpine: [main]   # no slim on alpine — alpine is already minimal
+
 releases:
   - version: 5.45.1
     sha256:  2b6d691916596835c411ee0181b6c66e4ee1c8d6ab60f8b0733c7c9cf8b58e3e
     extra_flags: "-Dusedevel -Dversiononly=undef"
-    debian_release:
-      - bullseye
-      - bookworm
-      - trixie
+    os_release:
+      - { family: debian, tag: bullseye }
+      - { family: debian, tag: bookworm }
+      - { family: debian, tag: trixie }
+      - { family: alpine, tag: alpine3.23 }
+      - { family: alpine, tag: alpine3.24 }
 
   - version: 5.40.5
     sha256:  09d926ae2d1b277c3bce62054c41da47c981380d719c41cf980b67945cc581ed
-    debian_release:
-      - bullseye
-      - bookworm
-      - trixie
+    os_release:
+      - { family: debian, tag: bullseye }
+      - { family: debian, tag: bookworm }
+      - { family: debian, tag: trixie }
+      - { family: alpine, tag: alpine3.23 }
+      - { family: alpine, tag: alpine3.24 }
 
   - version: 5.42.3
     sha256: 1137740985837b5cdf15f0cfab932279dcb4352f912fed6fc144e8b4f0823627
-    debian_release:
-      - bullseye
-      - bookworm
-      - trixie
+    os_release:
+      - { family: debian, tag: bullseye }
+      - { family: debian, tag: bookworm }
+      - { family: debian, tag: trixie }
+      - { family: alpine, tag: alpine3.23 }
+      - { family: alpine, tag: alpine3.24 }
 
   - version: 5.44.0
     sha256: 3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3
-    debian_release:
-      - bullseye
-      - bookworm
-      - trixie
+    os_release:
+      - { family: debian, tag: bullseye }
+      - { family: debian, tag: bookworm }
+      - { family: debian, tag: trixie }
+      - { family: alpine, tag: alpine3.23 }
+      - { family: alpine, tag: alpine3.24 }

--- a/generate.pl
+++ b/generate.pl
@@ -78,10 +78,13 @@ my $config = do {
   Load <$fh>;
 };
 
-my $template = do {
+sub load_template {
+  my $family = shift;
+  open my $fh, '<', "Dockerfile.$family.template"
+    or die "Couldn't open Dockerfile.$family.template: $!";
   local $/;
-  <DATA>;
-};
+  return <$fh>;
+}
 
 my %builds;
 
@@ -127,6 +130,13 @@ if (!-d "$downloads") {
   mkdir "$downloads" or die "Couldn't create a downloads directory at $downloads";
 }
 
+my %templates = (
+  debian => load_template('debian'),
+  alpine => load_template('alpine'),
+);
+
+my $constraints = $config->{build_constraints} // {};
+
 for my $build (@{$config->{builds}}) {
   $builds{$build} = $config->{options}{common};
   $builds{"$build,threaded"} = "@{$config->{options}}{qw/threaded common/}";
@@ -139,6 +149,8 @@ for my $release (@{$config->{releases}}) {
   die "Bad version: $release->{version}" unless $release->{version} =~ /\A5\.\d+\.\d+\Z/;
 
   my $patch;
+  my $busybox_ps_patch;
+  my $perl_src_dir;
   my $tarball = CPAN::Perl::Releases::MetaCPAN::perl_tarballs($release->{version})->{'tar.gz'};
   my ($file)  = File::Basename::fileparse($tarball);
   my $url     = "https://cpan.metacpan.org/authors/id/$tarball";
@@ -150,23 +162,46 @@ for my $release (@{$config->{releases}}) {
     getstore($url, "$downloads/$file");
   }
   {
-    my $dir = "$downloads/perl-$release->{version}";
-    qx{rm -fR $dir};
-    mkdir $dir or die "Couldn't create $dir";
+    $perl_src_dir = "$downloads/perl-$release->{version}";
+    qx{rm -fR $perl_src_dir};
+    mkdir $perl_src_dir or die "Couldn't create $perl_src_dir";
     qx{
-      tar -C "$downloads" -xf $dir.tar.gz &&\
-      cd $dir &&\
+      tar -C "$downloads" -xf $perl_src_dir.tar.gz &&\
+      cd $perl_src_dir &&\
       chown -R \$(id -u):\$(id -g) . &&\
       git init &&\
       git add . &&\
       git commit -m tmp
     };
     die "Couldn't create a temp git repo for $release->{version}" if $? != 0;
-    Devel::PatchPerl->patch_source($release->{version}, $dir);
+    Devel::PatchPerl->patch_source($release->{version}, $perl_src_dir);
     $patch = qx{
-      cd $dir && git -c 'diff.mnemonicprefix=false' diff
+      cd $perl_src_dir && git -c 'diff.mnemonicprefix=false' diff
     };
     die "Couldn't create a Devel::PatchPerl patch for $release->{version}" if $? != 0;
+
+    # Generate the per-Perl-version busybox-ps test skip patch, but only for
+    # releases that actually ship an alpine variant (nothing else consumes
+    # it). Keeps debian-only releases config-only and immune to a
+    # t/op/magic.t regex miss on a Perl version that never needed this patch.
+    if (grep { $_->{family} eq 'alpine' } @{$release->{os_release} // []}) {
+      # Line numbers in t/op/magic.t drift between Perl minors so this patch
+      # must be emitted per version, parallel to DevelPatchPerl.patch above.
+      # The substitution itself is stable: replace the prctl-detecting skip
+      # with a busybox-compatible one.
+      qx{cd $perl_src_dir && git add -A && git commit -m 'after-devel-patchperl' --allow-empty};
+      qx{
+        cd $perl_src_dir && perl -pi -E '
+          s{skip "We don.+?prctl\\(\\).+?".*?;}{skip "Skip test to avoid external ps(1) dependency", 2;}
+        ' t/op/magic.t
+      };
+      $busybox_ps_patch = qx{
+        cd $perl_src_dir && git -c 'diff.mnemonicprefix=false' diff
+      };
+      die "Couldn't create busybox-ps patch for $release->{version}" if $? != 0;
+      die "busybox-ps patch for $release->{version} is empty, regex may have missed t/op/magic.t"
+        unless $busybox_ps_patch =~ /\S/;
+    }
   }
 
   for my $build (keys %builds) {
@@ -178,57 +213,107 @@ for my $release (@{$config->{releases}}) {
     }
     $release->{"cpm_dist_$_"} = $cpm{$_} for keys %cpm;
 
-    $release->{extra_flags} ||= '';
+    $release->{extra_flags} //= '';
 
     $release->{image} = $build =~ /main/ ? 'buildpack-deps' : 'debian';
 
-    for my $debian_release (@{$release->{debian_release}}) {
+    for my $os (@{$release->{os_release}}) {
+      my ($family, $tag) = @{$os}{qw(family tag)};
 
-      my $output = $template;
+      # Honor build_constraints (e.g. no slim on alpine).
+      if (exists $constraints->{$family}) {
+        (my $core = $build) =~ s/,threaded$//;
+        next unless grep { $_ eq $core } @{$constraints->{$family}};
+      }
+
+      my $output = $templates{$family}
+        or die "No template loaded for family '$family'";
       $output =~ s/\{\{$_\}\}/$release->{$_}/mg for keys %$release;
       $output =~ s/\{\{args\}\}/$builds{$build}/mg;
 
-      if ($build =~ /slim/) {
-        $output =~ s/\{\{docker_slim_run_install\}\}/$docker_slim_run_install/mg;
-        $output =~ s/\{\{docker_slim_run_purge\}\}/$docker_slim_run_purge/mg;
-        $output =~ s/\{\{tag\}\}/$debian_release-slim/mg;
+      if ($family eq 'debian') {
+        if ($build =~ /slim/) {
+          $output =~ s/\{\{docker_slim_run_install\}\}/$docker_slim_run_install/mg;
+          $output =~ s/\{\{docker_slim_run_purge\}\}/$docker_slim_run_purge/mg;
+          $output =~ s/\{\{tag\}\}/$tag-slim/mg;
+        }
+        else {
+          $output =~ s/\{\{docker_slim_run_install\}\}/true/mg;
+          $output =~ s/\{\{docker_slim_run_purge\}\}/true/mg;
+          $output =~ s/\{\{tag\}\}/$tag/mg;
+        }
+      }
+      elsif ($family eq 'alpine') {
+        (my $alpine_tag_short = $tag) =~ s/^alpine//;
+        $output =~ s/\{\{alpine_tag_short\}\}/$alpine_tag_short/mg;
       }
       else {
-        $output =~ s/\{\{docker_slim_run_install\}\}/true/mg;
-        $output =~ s/\{\{docker_slim_run_purge\}\}/true/mg;
-        $output =~ s/\{\{tag\}\}/$debian_release/mg;
+        die "Unknown family '$family' for $release->{version}/$tag";
       }
 
-      my $dir = sprintf "%i.%03i.%03i-%s-%s", ($release->{version} =~ /(\d+)\.(\d+)\.(\d+)/), $build, $debian_release;
+      my $dir = sprintf "%i.%03i.%03i-%s-%s",
+        ($release->{version} =~ /(\d+)\.(\d+)\.(\d+)/), $build, $tag;
 
       mkdir $dir unless -d $dir;
 
-      # Set up the generated DevelPatchPerl.patch
+      # Set up the generated DevelPatchPerl.patch (shared across families).
       if ($patch) {
-        open my $fh, ">", "$dir/DevelPatchPerl.patch";
+        open my $fh, ">", "$dir/DevelPatchPerl.patch" or die "Couldn't write $dir/DevelPatchPerl.patch: $!";
         print $fh $patch;
+        close $fh;
         $output =~ s!\{\{docker_copy_perl_patch\}\}!COPY *.patch /usr/src/perl/!mg;
       }
       else {
         $output =~ s!\{\{docker_copy_perl_patch\}\}!# No DevelPatchPerl.patch generated!mg;
       }
 
+      # Alpine-specific patches: musl-stack-size (static) + skip-test-due-to-busybox-ps (per-version).
+      if ($family eq 'alpine') {
+        # Copy the static musl-stack-size.patch into the dir.
+        qx{cp musl-stack-size.patch "$dir/musl-stack-size.patch"};
+        die "Couldn't copy musl-stack-size.patch to $dir" if $? != 0;
+
+        # Write the per-version busybox-ps patch.
+        open my $fh, ">", "$dir/skip-test-due-to-busybox-ps.patch"
+          or die "Couldn't write $dir/skip-test-due-to-busybox-ps.patch: $!";
+        print $fh $busybox_ps_patch;
+        close $fh;
+
+        # Ensure the COPY *.patch line is enabled even if DevelPatchPerl.patch
+        # was empty for this version — musl patches need to be applied.
+        $output =~ s!^# No DevelPatchPerl.patch generated$!COPY *.patch /usr/src/perl/!mg;
+      }
+
       $release->{run_tests} //= "parallel";
-      if ($release->{run_tests} eq "serial") {
-        $output =~ s/\{\{test\}\}/make test_harness/;
-      }
-      elsif ($release->{run_tests} eq "parallel") {
-        $output =~ s/\{\{test\}\}/TEST_JOBS=\$(nproc) make test_harness/;
-      }
-      elsif ($release->{run_tests} eq "no") {
-
-        # https://metacpan.org/pod/Devel::PatchPerl#CAVEAT
-        $output =~ s/\{\{test\}\}/LD_LIBRARY_PATH=. .\/perl -Ilib -de0/;
-
-        # https://metacpan.org/pod/distribution/perl/INSTALL#Building-a-shared-Perl-library
+      if ($family eq 'alpine') {
+        # Alpine uses `test_harness_notty` per Alpine APKBUILD convention for
+        # no-tty Docker builds. Same parallel/serial/no semantics otherwise.
+        if ($release->{run_tests} eq "serial") {
+          $output =~ s/\{\{test_alpine\}\}/make test_harness_notty/;
+        }
+        elsif ($release->{run_tests} eq "parallel") {
+          $output =~ s/\{\{test_alpine\}\}/TEST_JOBS=\$(nproc) make test_harness_notty/;
+        }
+        elsif ($release->{run_tests} eq "no") {
+          $output =~ s/\{\{test_alpine\}\}/LD_LIBRARY_PATH=. .\/perl -Ilib -de0/;
+        }
+        else {
+          die "run_tests was provided for $release->{version} but is invalid; should be 'parallel', 'serial', or 'no'\n";
+        }
       }
       else {
-        die "run_tests was provided for $release->{version} but is invalid; should be 'parallel', 'serial', or 'no'\n";
+        if ($release->{run_tests} eq "serial") {
+          $output =~ s/\{\{test\}\}/make test_harness/;
+        }
+        elsif ($release->{run_tests} eq "parallel") {
+          $output =~ s/\{\{test\}\}/TEST_JOBS=\$(nproc) make test_harness/;
+        }
+        elsif ($release->{run_tests} eq "no") {
+          $output =~ s/\{\{test\}\}/LD_LIBRARY_PATH=. .\/perl -Ilib -de0/;
+        }
+        else {
+          die "run_tests was provided for $release->{version} but is invalid; should be 'parallel', 'serial', or 'no'\n";
+        }
       }
 
       open my $dockerfile, ">", "$dir/Dockerfile" or die "Couldn't open $dir/Dockerfile for writing";
@@ -252,8 +337,36 @@ generate.pl - generate Dockerfiles for Perl
 =head1 DESCRIPTION
 
 generate.pl is meant to be run from the actual repo directory, with a
-config.yml file correctly configured.  It contains with a 'releases'
-key, which contains a list of releases, each with the following keys:
+config.yml file correctly configured.
+
+The top-level config keys are:
+
+=over 4
+
+=item builds
+
+A list of build variant names (e.g. C<main>, C<slim>). Each build is
+also emitted in a threaded variant (C<main,threaded>).
+
+=item options
+
+A hash with C<common> and C<threaded> keys supplying C<Configure> flags
+shared across all releases.
+
+=item build_constraints
+
+An optional map from OS family name to an allowlist of build variants.
+When a family appears here, only the listed (non-threaded) builds are
+emitted for that family; the threaded counterparts follow automatically.
+If a family is absent, all builds apply. An empty list skips the family
+entirely.
+
+    build_constraints:
+      alpine: [main]   # no slim on alpine
+
+=back
+
+The C<releases> key contains a list of releases, each with the following keys:
 
 =over 4
 
@@ -275,20 +388,23 @@ The SHA-256 of the tarball for that release.
 
 =over 4
 
-=item debian_release
+=item os_release
 
-The Docker image tag which this Perl would build on, common to both the
-L<buildpack-deps|https://hub.docker.com/_/buildpack-deps> and
-L<debian|https://hub.docker.com/_/debian> Docker images.
+A list of OS targets this Perl release should be built for. Each entry
+is a hash with C<family> and C<tag> keys:
 
-This should be a list of tags for different Debian versions:
+    - version: 5.42.2
+      sha256: ...
+      os_release:
+        - { family: debian, tag: bullseye }
+        - { family: debian, tag: bookworm }
+        - { family: alpine, tag: alpine3.23 }
+        - { family: alpine, tag: alpine3.24 }
 
-    - version: 5.30.0
-      debian_release:
-        - bullseye
-        - buster
-
-C<-slim> will be appended to this value for C<slim> builds.
+C<family> is either C<debian> or C<alpine>. C<tag> is the OS-specific
+release tag. For Debian families, C<-slim> is appended to the tag for
+C<slim> builds. For Alpine families, only the builds listed in
+C<build_constraints> (top-level key) are emitted.
 
 =item extra_flags
 
@@ -305,54 +421,53 @@ Added due to dist/IO/t/io_unix.t failing when TEST_JOBS > 1, but should
 only be used in case of a documented issue or old release (see
 L<Devel::PatchPerl's CAVEAT|https://metacpan.org/pod/Devel::PatchPerl#CAVEAT>).
 
-Default: C<yes>
+Default: C<parallel>
 
 =back
+
+=back
+
+=head1 ALPINE VARIANT GENERATION
+
+For each release with C<family: alpine> entries in C<os_release>,
+C<generate.pl> performs additional steps:
+
+=over 4
+
+=item Template dispatch
+
+Alpine Dockerfiles are rendered from C<Dockerfile.alpine.template>
+instead of C<Dockerfile.debian.template>. The C<{{alpine_tag_short}}>
+template variable is derived by stripping the C<alpine> prefix from the
+OS tag (e.g. C<alpine3.23> → C<3.23>).
+
+=item musl-stack-size.patch
+
+The static C<musl-stack-size.patch> (in the repo root) is copied into
+every alpine output directory. It bumps the minimum thread stack size to
+256k, working around L<perl5#18160|https://github.com/Perl/perl5/issues/18160>
+which remains open on musl/Alpine.
+
+=item skip-test-due-to-busybox-ps.patch
+
+A per-Perl-version patch is generated by editing C<t/op/magic.t> to
+replace the C<prctl()>-detecting ps-skip with a busybox-compatible one.
+Because the relevant line numbers in C<t/op/magic.t> drift between Perl
+minors, this patch must be regenerated for each version rather than
+being static.
+
+=item C<COPY *.patch> always enabled
+
+For alpine directories, the C<COPY *.patch> Dockerfile line is
+force-enabled even when C<DevelPatchPerl.patch> is empty, so that the
+musl-specific patches are always applied.
+
+=item Test harness
+
+Alpine builds use C<test_harness_notty> instead of C<test_harness> (the
+C<{{test_alpine}}> template variable) per Alpine APKBUILD convention for
+no-tty Docker environments.
 
 =back
 
 =cut
-
-__DATA__
-FROM {{image}}:{{tag}}
-
-{{docker_copy_perl_patch}}
-WORKDIR /usr/src/perl
-
-RUN {{docker_slim_run_install}} \
-    && curl -fL {{url}} -o perl-{{version}}.tar.gz \
-    && echo '{{sha256}} *perl-{{version}}.tar.gz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-{{version}}.tar.gz -C /usr/src/perl \
-    && rm perl-{{version}}.tar.gz \
-    && cat *.patch | patch -p1 \
-    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
-    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
-    && ./Configure -Darchname="$gnuArch" "$archFlag" {{args}} {{extra_flags}} -des \
-    && make -j$(nproc) \
-    && {{test}} \
-    && make install \
-    && cd /usr/src \
-    && curl -fLO {{cpanm_dist_url}} \
-    && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum --strict --check - \
-    && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} \
-    && {{cpanm_dist_patch_https}} \
-    && {{cpanm_dist_patch_nolwp}} \
-    && perl bin/cpanm . && cd /root \
-    && curl -fLO '{{netssleay_dist_url}}' \
-    && echo '{{netssleay_dist_sha256}} *{{netssleay_dist_name}}.tar.gz' | sha256sum --strict --check - \
-    && cpanm --notest --from $PWD {{netssleay_dist_name}}.tar.gz \
-    && curl -fLO '{{iosocketssl_dist_url}}' \
-    && echo '{{iosocketssl_dist_sha256}} *{{iosocketssl_dist_name}}.tar.gz' | sha256sum --strict --check - \
-    && SSL_CERT_DIR=/etc/ssl/certs cpanm --from $PWD {{iosocketssl_dist_name}}.tar.gz \
-    && curl -fL {{cpm_dist_url}} -o /usr/local/bin/cpm \
-    # sha256 checksum is from docker-perl team, cf https://github.com/docker-library/official-images/pull/12612#issuecomment-1158288299
-    && echo '{{cpm_dist_sha256}} */usr/local/bin/cpm' | sha256sum --strict --check - \
-    && chmod +x /usr/local/bin/cpm \
-    && {{docker_slim_run_purge}} \
-    && rm -fr /root/.cpanm /root/{{netssleay_dist_name}}* /root/{{iosocketssl_dist_name}}* /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/* \
-    && cpanm --version && cpm --version
-
-WORKDIR /usr/src/app
-
-CMD ["perl{{version}}","-de0"]

--- a/library.pl
+++ b/library.pl
@@ -11,6 +11,12 @@ my %arches = (
   default  => 'amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x',
   bookworm => 'amd64, arm32v7, arm64v8, i386, ppc64le',
   bullseye => 'amd64, arm32v7, arm64v8, i386',
+
+  # https://github.com/docker-library/official-images/blob/master/library/alpine
+  # Same set across 3.23/3.24; kept per-tag so a future divergence is a
+  # one-line edit instead of a refactor.
+  'alpine3.23' => 'amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x',
+  'alpine3.24' => 'amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x',
 );
 
 print <<"END_HEADER";
@@ -29,7 +35,8 @@ sub suffix {
 sub entry {
   my $version = shift;
   my $build   = shift;
-  my $debian  = shift;
+  my $family  = shift;   # 'debian' or 'alpine'
+  my $tag     = shift;   # OS tag, e.g. 'bookworm' or 'alpine3.23'
   my $eol     = shift // 0;
 
   my @versionAliases = ();
@@ -45,36 +52,80 @@ sub entry {
   else {
     push @versionAliases, 'latest', 'stable';
   }
- 
+
   (my $buildSuffix = $build) =~ s/^main,//;
   $buildSuffix =~ s/,/-/g;
   my @buildAliases = ($build eq 'main' ? @versionAliases : suffix $buildSuffix, @versionAliases);
 
-  my @debianAliases = suffix $debian, @buildAliases;
+  # Tag-specific aliases (e.g. '5.42.2-alpine3.23') always emitted.
+  my @tagAliases = suffix $tag, @buildAliases;
 
-  my @aliases = (($eol ? () : @buildAliases), @debianAliases);
+  # Bare-family aliases (e.g. '5.42.2-alpine') emitted for non-debian
+  # families so users can pull 'perl:alpine' like they pull 'perl:slim'.
+  # The state %latest dedup below guarantees only the first-seen entry
+  # per family per Perl version wins these short aliases.
+  my @familyAliases = $family eq 'debian' ? () : suffix $family, @buildAliases;
+
+  my @aliases = (($eol ? () : @buildAliases), @familyAliases, @tagAliases);
 
   state %latest = ();
   @aliases = grep { !defined $latest{$_} } @aliases;
   @latest{@aliases} = (1) x @aliases;
 
+  # For debian, an unlisted tag safely falls back to the header's default
+  # Architectures line (e.g. trixie has no override because it matches
+  # default). Non-debian families have no such safe fallback: the header
+  # default is debian-shaped (e.g. includes arm32v5, excludes i386), so a
+  # missing %arches entry for e.g. a new alpine tag would silently publish
+  # the wrong architecture list instead of failing loudly.
+  warn "No \%arches entry for '$tag' (family '$family') in library.pl."
+    . " Falling back to the debian-shaped default Architectures list, which is"
+    . " probably wrong for this family. Add a '$tag' entry to \%arches.\n"
+    if $family ne 'debian' && !defined $arches{$tag};
+
   print <<~"END_ENTRY";
 
-	Tags: @{[ join ', ', @aliases ]}@{[ defined $arches{$debian} ? "\nArchitectures: $arches{$debian}" : '' ]}
-	Directory: @{[ ($eol ? 'eol/' : '') . sprintf '%i.%03i.%03i-%s-%s', @version, $build, $debian ]}
+	Tags: @{[ join ', ', @aliases ]}@{[ defined $arches{$tag} ? "\nArchitectures: $arches{$tag}" : '' ]}
+	Directory: @{[ ($eol ? 'eol/' : '') . sprintf '%i.%03i.%03i-%s-%s', @version, $build, $tag ]}
 	END_ENTRY
 }
 
 sub release {
-  my $release = shift;
-  my $builds  = shift;
-  my $eol     = shift // 0;
+  my $release     = shift;
+  my $builds      = shift;
+  my $constraints = shift // {};
+  my $eol         = shift // 0;
+
+  # Backwards compat for eol/config.yml: synthesize os_release from
+  # legacy debian_release. Lets us defer migrating the EOL backfill
+  # config without breaking manifest emission.
+  if (!exists $release->{os_release} && exists $release->{debian_release}) {
+    $release->{os_release} = [
+      map { { family => 'debian', tag => $_ } } @{$release->{debian_release}}
+    ];
+  }
 
   my @builds = (@$builds, map {"$_,threaded"} @$builds);
 
+  # Partition so debian wins top-level unsuffixed aliases and the newest
+  # alpine wins rolling `-alpine` aliases. Within each group, reverse so
+  # the LAST listed entry in config.yml (typically the newest tag) is
+  # consumed first by the state %latest dedup.
+  my @debian_entries = grep { $_->{family} eq 'debian' } @{$release->{os_release}};
+  my @other_entries  = grep { $_->{family} ne 'debian' } @{$release->{os_release}};
+
   for my $build (@builds) {
-    for my $debian (reverse @{$release->{debian_release}}) {
-      entry $release->{version}, $build, $debian, $eol;
+    for my $os (reverse(@debian_entries), reverse(@other_entries)) {
+      my ($family, $tag) = @{$os}{qw(family tag)};
+
+      # Honor build_constraints: if the family has an allowlist, the
+      # core build (sans ',threaded') must be in it.
+      if (exists $constraints->{$family}) {
+        (my $core = $build) =~ s/,threaded$//;
+        next unless grep { $_ eq $core } @{$constraints->{$family}};
+      }
+
+      entry $release->{version}, $build, $family, $tag, $eol;
     }
   }
 }
@@ -85,7 +136,7 @@ my $config = do {
   Load <$fh>;
 };
 
-release $_, $config->{builds} for reverse @{$config->{releases}};
+release $_, $config->{builds}, $config->{build_constraints} for reverse @{$config->{releases}};
 
 exit unless @ARGV == 1 && $ARGV[0] eq '--eol';
 
@@ -104,7 +155,7 @@ $config = do {
   Load <$fh>;
 };
 
-release $_, $config->{builds}, 1 for reverse @{$config->{releases}};
+release $_, $config->{builds}, $config->{build_constraints}, 1 for reverse @{$config->{releases}};
 
 =pod
 
@@ -128,5 +179,53 @@ L<official Docker Perl images|https://hub.docker.com/_/perl>.
 This script optionally takes an C<--eol> option, for including entries
 corresponding to unsupported Perl versions that require a rebuild on the
 Docker Hub as needed (e.g. for updating base image dependencies.)
+
+=head1 FUNCTIONS
+
+=head2 entry($version, $build, $family, $tag, $eol)
+
+Emits a single Docker image manifest stanza for the given combination of
+Perl C<$version> (e.g. C<5.42.2>), build variant C<$build> (e.g. C<main>,
+C<main,threaded>), OS C<$family> (C<debian> or C<alpine>), OS C<$tag>
+(e.g. C<bookworm>, C<alpine3.23>), and optional C<$eol> flag.
+
+=head3 Tag Aliasing
+
+Two alias groups are emitted per entry:
+
+=over 4
+
+=item Pinned tag aliases
+
+Always emitted. Include the OS tag as a suffix (e.g. C<5.42.2-alpine3.23>,
+C<5.42.2-threaded-alpine3.23>).
+
+=item Rolling family aliases
+
+Emitted for non-C<debian> families only (e.g. C<5.42.2-alpine>,
+C<5.42.2-threaded-alpine>). This lets users pull C<perl:alpine> the same
+way they pull C<perl:slim>.
+
+=back
+
+A C<state %latest> dedup table ensures each alias is claimed by at most
+one entry. The emission order in C<release()> (debian entries first,
+then other families, each group reversed) guarantees that Debian entries
+win top-level unsuffixed aliases and the newest alpine tag (last in
+C<config.yml>) wins the rolling C<-alpine> aliases.
+
+=head2 release($release, $builds, $constraints, $eol)
+
+Emits manifest stanzas for all build × OS combinations for a single
+C<$release> hash (as read from C<config.yml>).
+
+C<$constraints> is the C<build_constraints> hash from C<config.yml>:
+when a family appears in it, only the listed core build variants are
+emitted for that family (threaded counterparts are added automatically).
+
+Includes a backwards-compatibility shim: if C<os_release> is absent but
+C<debian_release> is present (used by C<eol/config.yml> entries), it
+synthesises C<os_release> from the legacy key so EOL entries do not need
+to be migrated.
 
 =cut

--- a/musl-stack-size.patch
+++ b/musl-stack-size.patch
@@ -1,0 +1,16 @@
+Tests fails on s390x due to low thread stack size
+upstream report: https://github.com/Perl/perl5/issues/18160
+
+diff --git a/t/thread_it.pl b/t/thread_it.pl
+index f38a580..e8c450a 100644
+--- a/t/thread_it.pl
++++ b/t/thread_it.pl
+@@ -36,7 +36,7 @@ my $curr = threads->create({
+                             stack_size => $^O eq 'hpux'   ? 524288 :
+                                           $^O eq 'darwin' ? 2000000:
+                                           $^O eq 'VMS'    ? 150000 :
+-                                          $^O eq 'aix'    ? 1500000 : 0,
++                                          $^O eq 'aix'    ? 1500000 : 256*1024,
+                            }, sub {
+ 			       run_tests();
+ 			       return defined &curr_test ? curr_test() : ()

--- a/t/alpine-checks.t
+++ b/t/alpine-checks.t
@@ -1,0 +1,196 @@
+#!/usr/bin/env perl
+use 5.014;
+use strict;
+use warnings;
+use Test::More;
+use YAML::XS qw(LoadFile);
+use File::Basename qw(dirname);
+use Cwd qw(abs_path);
+
+my $root = abs_path(dirname(__FILE__) . '/..');
+chdir $root or BAIL_OUT("couldn't chdir to $root: $!");
+
+my @alpine_dirs = sort grep { -d } glob '*-alpine*';
+BAIL_OUT("no *-alpine* directories found, has generate.pl been run?")
+  unless @alpine_dirs;
+
+diag("Found " . scalar(@alpine_dirs) . " alpine directories.");
+
+my $config = LoadFile('config.yml');
+
+# Expected count: each `family: alpine` os_release entry across all releases,
+# times 2 threading variants (main and main,threaded).
+my @alpine_tags;
+for my $release (@{$config->{releases}}) {
+  push @alpine_tags, map { $_->{tag} }
+    grep { $_->{family} eq 'alpine' } @{$release->{os_release} // []};
+}
+my $expected_alpine = @alpine_tags * 2;
+
+is(scalar(@alpine_dirs), $expected_alpine,
+  "expected exactly $expected_alpine alpine directories");
+
+# Adversarial: no slim+alpine combinations should exist.
+my @slim_alpine = grep { /slim/ } @alpine_dirs;
+is(scalar(@slim_alpine), 0,
+  "no slim+alpine directories (build_constraints violation)")
+  or diag("found: @slim_alpine");
+
+# Adversarial: each known alpine tag must individually have the right count
+# (the total can mask a tag being entirely missing if another has double).
+my @atags = sort keys %{{map { $_ => 1 } @alpine_tags}};
+my $expected_per_tag = @atags ? $expected_alpine / @atags : 0;
+for my $atag (@atags) {
+  my @tag_dirs = grep { /-\Q$atag\E\z/ } @alpine_dirs;
+  is(scalar(@tag_dirs), $expected_per_tag,
+    "$atag: expected $expected_per_tag directories");
+}
+
+for my $dir (@alpine_dirs) {
+  subtest $dir => sub {
+    open my $fh, '<', "$dir/Dockerfile"
+      or BAIL_OUT("couldn't read $dir/Dockerfile: $!");
+    local $/;
+    my $dockerfile = <$fh>;
+    close $fh;
+
+    # Static: patches present, non-empty, and contain expected content.
+    my $musl_patch = "$dir/musl-stack-size.patch";
+    if (ok(-s $musl_patch, "musl-stack-size.patch present and non-empty")) {
+      like(slurp($musl_patch), qr/256\*1024/,
+        "musl-stack-size.patch has the expected stack-size hunk");
+    }
+
+    my $busybox_patch = "$dir/skip-test-due-to-busybox-ps.patch";
+    if (ok(-s $busybox_patch, "skip-test-due-to-busybox-ps.patch present and non-empty")) {
+      like(slurp($busybox_patch),
+        qr/Skip test to avoid external ps\(1\) dependency/,
+        "skip-test-due-to-busybox-ps.patch has the expected busybox-ps skip hunk");
+    }
+
+    # Static: Dockerfile copies patches into build context, then applies them.
+    like($dockerfile, qr/COPY \*\.patch/,
+      "Dockerfile copies *.patch into build context");
+    like($dockerfile, qr/cat \*\.patch \| patch -p1/,
+      "Dockerfile applies patches (cat *.patch | patch -p1)");
+    like($dockerfile, qr/make test_harness_notty/,
+      "Dockerfile uses test_harness_notty");
+
+    like($dockerfile, qr/^FROM alpine:/m, "Dockerfile is FROM alpine:<tag>");
+
+    # Adversarial: FROM alpine tag must be well-formed N.NN (not 'latest',
+    # 'edge', etc), and must match the alpine tag encoded in the directory name.
+    my ($alpine_tag) = $dockerfile =~ /^FROM alpine:(\S+)/m;
+    if (ok(defined($alpine_tag), "found a FROM alpine: tag")) {
+      like($alpine_tag, qr/^\d+\.\d+\z/,
+        "FROM alpine tag '$alpine_tag' is well-formed (N.NN)");
+
+      my ($dir_alpine_tag) = $dir =~ /(alpine[\d.]+)\z/;
+      is("alpine$alpine_tag", $dir_alpine_tag,
+        "FROM alpine:$alpine_tag matches directory tag $dir_alpine_tag");
+    }
+
+    # Adversarial: -Dusethreads in ./Configure must align with whether the
+    # directory is a threaded variant.
+    my ($configure_line) = $dockerfile =~ /^(.*\.\/Configure.*)$/m;
+    $configure_line //= '';
+    my $is_threaded = $dir =~ /,threaded/;
+    my $has_usethreads = $configure_line =~ /-Dusethreads/;
+    is(!!$has_usethreads, !!$is_threaded,
+      $is_threaded
+        ? "threaded variant has -Dusethreads in ./Configure"
+        : "non-threaded variant has no -Dusethreads in ./Configure");
+
+    # Static: tzdata must appear in the permanent apk add block.
+    like($dockerfile, qr/tzdata/, "Dockerfile installs tzdata");
+
+    # Static: CMD must reference the perl version that matches the directory name.
+    my ($dir_version) = $dir =~ /^([\d.]+)-/;
+    my $expected_version = join '.', map { $_ + 0 } split /\./, $dir_version;
+    my ($cmd_version) = $dockerfile =~ /^CMD.*?perl([\d.]+)"/m;
+    is($cmd_version, $expected_version,
+      "CMD references perl$expected_version");
+
+    # Static: cpanm must have the HTTPS URL rewrite, no-LWP, and no-wget
+    # patches applied (busybox wget lacks --retry-connrefused).
+    like($dockerfile, qr/s\{http:\/\//, "cpanm HTTPS URL rewrite patch present");
+    like($dockerfile, qr/try_lwp=>0/, "cpanm no-LWP patch present");
+    like($dockerfile, qr/try_wget=>0/, "cpanm no-wget patch present");
+
+    # Runtime checks (optional, requires already-built perl:<tag> images).
+    SKIP: {
+      skip "RUN_RUNTIME not set", 7 unless $ENV{RUN_RUNTIME};
+
+      # Repo convention (see .github/workflows/build-image.yml): tag the
+      # built image as perl:${dir//,/-}. Comma in `main,threaded` becomes a
+      # dash, because Docker tags don't accept commas.
+      (my $tag_suffix = $dir) =~ s/,/-/g;
+      my $tag = "perl:$tag_suffix";
+
+      is(system(qw(docker run --rm), $tag, qw(sh -c),
+          'apk info -e build-base make openssl-dev linux-headers libc-dev zlib-dev bzip2-dev ca-certificates curl > /dev/null'),
+        0, "$tag retains all permanent apk packages");
+
+      # Checked per-package so partial retention (e.g. only 'patch' left
+      # behind) is not missed by a single combined query.
+      my $retained = 0;
+      for my $pkg (qw(dpkg dpkg-dev patch procps tar xz)) {
+        if (system(qw(docker run --rm), $tag, qw(sh -c),
+            'apk info -e "$1" > /dev/null 2>&1', 'sh', $pkg) == 0) {
+          diag("$tag retained transient build-dep: $pkg (should have been apk del'd)");
+          $retained = 1;
+        }
+      }
+      ok(!$retained, "$tag purged all transient build-deps");
+
+      is(system(qw(docker run --rm), $tag, qw(sh -c),
+          'which gcc && which make && pkg-config --exists openssl'),
+        0, "$tag toolchain (gcc, make, openssl) reachable at runtime");
+
+      is(system(qw(docker run --rm), $tag, qw(perl -e),
+          'use POSIX; my $l = POSIX::setlocale(POSIX::LC_ALL, ""); print defined($l) ? $l : "undef"; print "\n"'),
+        0, "$tag POSIX::setlocale does not die");
+
+      is(system(qw(docker run --rm), $tag, qw(perl -e), 'use Net::SSLeay; use IO::Socket::SSL'),
+        0, "$tag can load Net::SSLeay and IO::Socket::SSL");
+
+      SKIP: {
+        skip "not a threaded variant", 1 unless $is_threaded;
+        is(system(qw(docker run --rm), $tag, qw(perl -e), 'use threads; threads->create(sub {})->join'),
+          0, "$tag threaded variant can create and join a thread");
+      }
+
+      is(system(qw(docker run --rm), $tag, qw(cpanm -n Linux::Inotify2)),
+        0, "$tag can install Linux::Inotify2 (XS musl/linux-headers smoke)");
+    }
+  };
+}
+
+done_testing();
+
+sub slurp {
+  my ($file) = @_;
+  open my $fh, '<', $file or BAIL_OUT("couldn't read $file: $!");
+  local $/;
+  return <$fh>;
+}
+
+=pod
+
+=head1 NAME
+
+alpine-checks.t - static and (optional) runtime checks for the alpine variant
+
+=head1 SYNOPSIS
+
+    prove t/alpine-checks.t                  # static only
+    RUN_RUNTIME=1 prove t/alpine-checks.t    # also runtime (requires built images)
+
+=head1 DESCRIPTION
+
+Static checks assert against the generated Dockerfile and patch presence
+for every C<*-alpine*> directory. Runtime checks (gated on C<RUN_RUNTIME=1>)
+run C<docker run> assertions against already-built C<perl:E<lt>tagE<gt>>
+images and are skipped otherwise.
+
+=cut

--- a/t/check-patch-consistency.t
+++ b/t/check-patch-consistency.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+use 5.014;
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(abs_path);
+use File::Basename qw(dirname);
+use Pod::Usage qw(pod2usage);
+
+pod2usage(-verbose => 1, -exitval => 0)
+  if @ARGV && ($ARGV[0] eq '-h' || $ARGV[0] eq '--help');
+
+my $root;
+if (!@ARGV) {
+  $root = abs_path(dirname(__FILE__) . '/..');
+}
+elsif ($ARGV[0] =~ /^-/) {
+  BAIL_OUT("unknown option: $ARGV[0]");
+}
+else {
+  BAIL_OUT("not a directory: $ARGV[0]") unless -d $ARGV[0];
+  $root = abs_path($ARGV[0]);
+}
+
+chdir $root or BAIL_OUT("couldn't chdir to $root: $!");
+
+BAIL_OUT("$root is not inside a git work tree (git ls-files unavailable)")
+  unless system('sh', '-c', 'git rev-parse --is-inside-work-tree >/dev/null 2>&1') == 0;
+
+my @to_check;
+for my $dockerfile (sort glob '*/Dockerfile') {
+  open my $fh, '<', $dockerfile or BAIL_OUT("couldn't read $dockerfile: $!");
+  local $/;
+  my $content = <$fh>;
+  close $fh;
+
+  # Alpine-specific marker: only alpine variants build FROM alpine:<tag>.
+  next unless $content =~ /^FROM alpine:/m;
+
+  # Only care about Dockerfiles that actually depend on patch files.
+  next unless $content =~ /COPY \*\.patch/ || $content =~ /patch -p1/;
+
+  (my $dir = $dockerfile) =~ s{/Dockerfile\z}{};
+  push @to_check, $dir;
+}
+
+if (!@to_check) {
+  plan skip_all => "found no alpine Dockerfiles that depend on patches, has generate.pl been run?";
+}
+
+for my $dir (@to_check) {
+  subtest $dir => sub {
+    my @patches = sort glob "$dir/*.patch";
+
+    if (!@patches) {
+      fail("$dir/Dockerfile requires patches (COPY *.patch / patch -p1)"
+        . " but no *.patch files exist in $dir/,"
+        . " docker build would fail at the COPY step on a fresh clone");
+      return;
+    }
+
+    for my $patch (@patches) {
+      # Pass $patch as a positional arg to the inner shell (rather than
+      # interpolating it into the command string) so list-form system()
+      # still gets the >/dev/null redirect without any quoting concerns.
+      system('sh', '-c', 'git ls-files --error-unmatch "$1" >/dev/null 2>&1', 'sh', $patch);
+      ok($? == 0, "$patch is tracked by git")
+        or diag("$patch exists on disk but is NOT tracked by git,"
+          . " a fresh clone won't have it, so 'COPY *.patch' in $dir/Dockerfile will fail."
+          . " Fix: git add $patch");
+    }
+  };
+}
+
+done_testing();
+
+=pod
+
+=head1 NAME
+
+check-patch-consistency.t - alpine Dockerfile patches present and tracked
+
+=head1 SYNOPSIS
+
+    prove t/check-patch-consistency.t                 # scan this repo
+    prove t/check-patch-consistency.t :: /some/dir    # scan a specific repo/worktree
+    perl t/check-patch-consistency.t --help
+
+=head1 DESCRIPTION
+
+Each generated alpine Dockerfile does C<COPY *.patch /usr/src/perl/> and then
+C<cat *.patch | patch -p1>. If those patch files are missing, or exist on
+disk but are not committed, a fresh C<git clone> will not have them.
+Under current BuildKit/ash semantics this is a silent failure, not a loud
+one: C<COPY> with zero glob matches no-ops, and C<cat *.patch | patch -p1>
+on empty input exits 0 without C<pipefail>. This test catches that class of
+bug statically, before any image is built.
+
+Read-only: inspects files and queries git, never modifies the working tree.
+
+=cut


### PR DESCRIPTION
Resolves #23. Adds Alpine Linux variants of the official `perl` images, templated through `generate.pl` rather than hand-edited per Perl version.

## What changed

- **Templated, not hand-edited.** New `Dockerfile.alpine.template` (and a sibling `Dockerfile.debian.template` extracted from the old `__DATA__` block). `generate.pl` dispatches by family.
- **Schema:** `config.yml` `debian_release` becomes `os_release: [{family, tag}]`. New `build_constraints` key expresses "no slim on alpine".
- **Two alpine tags per Perl version:** `alpine3.23` and `alpine3.24` (mirroring `python:3-alpine` / `ruby:3-alpine` cadence: current stable plus previous stable).
- **No `setlocale()` workaround.** Per current state of musl 1.2 + Perl 5.28+, the workaround is unnecessary.
- **Patches per alpine dir**, committed alongside the generated `Dockerfile` (same convention as the existing non-alpine dirs):
  - `DevelPatchPerl.patch`: the same `Devel::PatchPerl` output already used for Debian variants; only written when the diff is non-empty for that Perl version.
  - `musl-stack-size.patch` (static; bumps threaded stack floor to 256k, works around upstream Perl/perl5#18160 which remains open).
  - `skip-test-due-to-busybox-ps.patch` (generated per Perl version since the relevant line in `t/op/magic.t` drifts between minors; guard added so an empty patch fails loudly rather than silently).
  - A new `t/check-patch-consistency.t` statically verifies every alpine Dockerfile's required patches are present on disk and git-tracked, so a fresh clone can never be missing a patch its Dockerfile depends on.
- **Build toolchain retained at runtime** (parallel to debian-main's buildpack-deps base; diverges from `python:3-alpine` / `ruby:3-alpine` which scanelf-prune the compiler). Requires `openssl` and `pkgconf` in addition to `openssl-dev`, confirmed via live build test.
- **tzdata included** for DST timezone test coverage (`ext/POSIX/t/time.t` DST transition tests require `/usr/share/zoneinfo/`).
- **HTTPS regression closed:** Net::SSLeay 1.96, IO::Socket::SSL 2.099, cpanm 1.7049, and cpm v1.1.4 install at build time, matching debian-main parity. Both use `--notest` since their test suites make live TLS connections that are unreliable in isolated build environments; SSL correctness is verified by the CI "Run HTTPS access test" step.
- **CI:** uses existing `.github/workflows/build-image.yml` auto-discovery (`dirname */Dockerfile`). Added `fail-fast: false` so one variant failure no longer cancels all other jobs. No-lwp test uses `sh` instead of `bash` (Alpine only ships busybox `sh`). `generate-dockerfiles-patches.yml` now runs the `t/` regression suite via `prove -v t/*.t` after regenerating, and its trigger paths cover every generation input (`generate.pl`, `library.pl`, both Dockerfile templates, `musl-stack-size.patch`, and `t/**`), so a change to any of them exercises the generate-and-diff check.
- **library.pl:** family-aware; emits both pinned (`<version>-alpine3.24`) and rolling (`<version>-alpine`, aliasing current stable) tags per the Ruby/Python convention.
- **`wget` removed** from the permanent `apk add` block; all downloads use `curl`, saving about 3.4 MiB per image.
- **cpanm wget disabled:** cpanm 1.7049 has `try_wget=>1` by default; after patching `try_lwp=>0`, cpanm would fall through to wget before curl. Busybox `wget` lacks `--retry-connrefused` (a GNU wget flag cpanm passes unconditionally), causing build failures. Patched with `perl -pi -E 's{try_wget=>1}{try_wget=>0}g'` so cpanm uses curl directly.
- **sha256sum asymmetry documented:** Alpine uses `sha256sum -c -` (busybox sha256sum lacks `--strict`); Debian uses `sha256sum --strict --check -`. Each Dockerfile carries an inline comment explaining the intentional divergence.

## Documentation

- **`generate.pl` POD** rewritten: `run_tests` default corrected to `parallel`, `os_release` schema documented (replaces legacy `debian_release`), `build_constraints` key explained with example, Alpine Variant Generation section added.
- **`library.pl` POD** added: `=head1 FUNCTIONS` documents `entry()` and `release()` with tag aliasing strategy and EOL compat shim.
- **README** updated: new "Alpine Variants" section with a Perl-version-independent published-tags table, and a Caveats list covering musl libc quirks, the stack-size patch, toolchain retention, `tzdata`, and busybox `sh` as the default shell.

## Checklist

- [x] Build without `setlocale()` workaround (musl 1.2 + Perl 5.28+ obsoletes it)
- [x] Retain `make` plus full build toolchain so cpanm XS installs work
- [x] Apply for all Perl versions via templating
- [x] Live build and smoke test: `perl 5.42.2`, `Net::SSLeay 1.96`, `IO::Socket::SSL 2.099`, gcc toolchain retained, `.build-deps` purged
- [x] Every alpine Dockerfile's patches present on disk and git-tracked (`t/check-patch-consistency.t`)
- [x] POD documentation for `generate.pl` and `library.pl`
- [x] README caveats for Alpine-specific behaviour

## Testing

The regression suite lives in `t/` as Perl/`Test::More`, run with `prove`:
`prove -r t/`. `t/alpine-checks.t` runs static checks unconditionally, with
runtime checks gated on `RUN_RUNTIME=1`. `t/check-patch-consistency.t` is
static, always. Both read the generated files, so run `./generate.pl` first
on a fresh checkout.

**Static (always):**
- Directory count derived from `config.yml` (`family: alpine` entries times 2 threading variants)
- No `slim+alpine` combinations (enforces `build_constraints`)
- Per-tag balance: each alpine tag derived from `config.yml` must have the right count individually
- Each Dockerfile: `COPY *.patch`, `cat *.patch | patch -p1`, `make test_harness_notty`, `FROM alpine:N.NN`
- `FROM alpine:` tag matches directory name
- `-Dusethreads` in `./Configure` matches `,threaded` in directory name
- `tzdata` in permanent `apk add` block
- `CMD` perl version matches directory name (zero-pad stripped)
- cpanm patches present: HTTPS URL rewrite (`s{http://`), no-LWP (`try_lwp=>0`), and no-wget (`try_wget=>0`)
- Patch files non-empty and contain expected content (`256*1024` hunk, busybox-ps skip message)
- Every `*.patch` a Dockerfile depends on is present on disk and git-tracked (`check-patch-consistency.t`)

**Runtime (`RUN_RUNTIME=1`):**
- Permanent toolchain packages retained (`build-base`, `make`, `openssl-dev`, `linux-headers`, `libc-dev`, `zlib-dev`, `bzip2-dev`, `ca-certificates`, `curl`)
- Transient `.build-deps` purged, checked per-package so partial retention is caught
- Compiler reachable (`which gcc`, `which make`, `pkg-config --exists openssl`)
- `POSIX::setlocale` does not die; actual locale value printed for CI logs
- `use Net::SSLeay; use IO::Socket::SSL`: verifies `--notest` installs are loadable
- Threaded variants: `threads->create(sub {})->join` smoke
- XS compile against `linux-headers`: `Linux::Inotify2` (`sys/inotify.h`)

Closes #23.

