### PR TITLE
Add vendor paths

### DIFF
--- a/generate.pl
+++ b/generate.pl
@@ -36,9 +36,14 @@ my $template = do {
   <DATA>;
 };
 
+my $common = join " ", qw{
+-Duseshrplib
+-Dvendorprefix=/usr/local
+};
+
 my %builds = (
-  "64bit"          => "-Duse64bitall -Duseshrplib",
-  "64bit,threaded" => "-Dusethreads -Duse64bitall -Duseshrplib",
+  "64bit"          => "-Duse64bitall $common",
+  "64bit,threaded" => "-Dusethreads -Duse64bitall $common",
 );
 
 die_with_sample unless defined $yaml->{releases};

--- a/generate.pl
+++ b/generate.pl
@@ -157,7 +157,7 @@ The PAUSE (CPAN user) account that the release was uploaded to.
 
 =over 4
 
-=item extra_args
+=item extra_flags
 
 Additional text to pass to C<Configure>.  At the moment, this is necessary for
 5.18.x so that it can get the C<-fwrapv> flag.


### PR DESCRIPTION
Let `vendorprefix=/usr/local` so `vendorlib` and `vendorarch` can point
to paths in `/usr/local/lib/perl5/vendor_perl`.  Extend the generator.pl
also so we can add more `Configure` settings if we needed it later.

Fixes #32.