### PR TITLE
Use tagged buildpack-deps

### DIFF
--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:jessie
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.024.002-64bit,threaded/Dockerfile
+++ b/5.024.002-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.024.002-64bit,threaded/Dockerfile
+++ b/5.024.002-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.024.002-64bit,threaded/Dockerfile
+++ b/5.024.002-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.024.002-64bit/Dockerfile
+++ b/5.024.002-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.024.002-64bit/Dockerfile
+++ b/5.024.002-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.024.002-64bit/Dockerfile
+++ b/5.024.002-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.026.000-64bit,threaded/Dockerfile
+++ b/5.026.000-64bit,threaded/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.026.000-64bit,threaded/Dockerfile
+++ b/5.026.000-64bit,threaded/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.026.000-64bit,threaded/Dockerfile
+++ b/5.026.000-64bit,threaded/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/5.026.000-64bit/Dockerfile
+++ b/5.026.000-64bit/Dockerfile
@@ -1,10 +1,6 @@
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl

--- a/5.026.000-64bit/Dockerfile
+++ b/5.026.000-64bit/Dockerfile
@@ -1,7 +1,6 @@
 FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/5.026.000-64bit/Dockerfile
+++ b/5.026.000-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps
+FROM buildpack-deps:stretch
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/Releases.yaml
+++ b/Releases.yaml
@@ -4,36 +4,42 @@ releases:
     pause:   NWCLARK
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.10.1
     sha256:  9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826
     pause:   DAPM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.12.5
     sha256:  10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c
     pause:   DOM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.14.4
     sha256:  eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745
     pause:   DAPM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.16.3
     sha256:  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8
     pause:   RJBS
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.18.4
     sha256:  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5
     pause:   RJBS
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
+    buildpack_deps: jessie
 
   - version: 5.20.3
     sha256:  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b

--- a/generate.pl
+++ b/generate.pl
@@ -90,10 +90,11 @@ for my $release (@{$yaml->{releases}}) {
 
   $release->{pause} =~ s#(((.).).*)#$3/$2/$1#;
   $release->{extra_flags} = "" unless defined $release->{extra_flags};
+  $release->{_tag} = $release->{buildpack_deps} || "stretch";
 
   for my $config (keys %builds) {
     my $output = $template;
-    $output =~ s/\{\{$_\}\}/$release->{$_}/mg for (qw(version pause extra_flags sha256));
+    $output =~ s/\{\{$_\}\}/$release->{$_}/mg for (qw(version pause extra_flags sha256 _tag));
     $output =~ s/\{\{args\}\}/$builds{$config}/mg;
 
     my $dir = sprintf "%i.%03i.%03i-%s",
@@ -162,6 +163,13 @@ The PAUSE (CPAN user) account that the release was uploaded to.
 
 =over 4
 
+=item buildpack_deps
+
+The Docker L<buildpack-deps|https://hub.docker.com/_/buildpack-deps>
+image tag which this Perl would build on.
+
+Defaults: C<stretch>
+
 =item extra_flags
 
 Additional text to pass to C<Configure>.  At the moment, this is necessary for
@@ -184,7 +192,7 @@ Default: C<yes>
 =cut
 
 __DATA__
-FROM buildpack-deps
+FROM buildpack_deps:{{_tag}}
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/generate.pl
+++ b/generate.pl
@@ -195,7 +195,6 @@ __DATA__
 FROM buildpack-deps:{{_tag}}
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 

--- a/generate.pl
+++ b/generate.pl
@@ -192,7 +192,7 @@ Default: C<yes>
 =cut
 
 __DATA__
-FROM buildpack_deps:{{_tag}}
+FROM buildpack-deps:{{_tag}}
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
 RUN mkdir /usr/src/perl

--- a/generate.pl
+++ b/generate.pl
@@ -187,10 +187,6 @@ __DATA__
 FROM buildpack-deps
 MAINTAINER Peter Martini <PeterCMartini@GMail.com>
 
-RUN apt-get update \
-    && apt-get install -y curl procps \
-    && rm -fr /var/lib/apt/lists/*
-
 RUN mkdir /usr/src/perl
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl


### PR DESCRIPTION
Add a `buildpack-deps` option that lets us specify what tag to use on
building Perl images.  This can then let us build older Perls (<5.20)
against their contemporary build stack.

Fixes #34.