### PR TITLE
Use canonical url for perl downloads

### DIFF
--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/5.024.002-64bit,threaded/Dockerfile
+++ b/5.024.002-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar.bz2 \
     && echo 'e28c8fa588c4227eb25350036b45d7b1b46d61bb3a2194ee09dc79be6ed0fd0f *perl-5.24.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.24.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.2.tar.bz2 \

--- a/5.024.002-64bit/Dockerfile
+++ b/5.024.002-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar.bz2 \
     && echo 'e28c8fa588c4227eb25350036b45d7b1b46d61bb3a2194ee09dc79be6ed0fd0f *perl-5.24.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.24.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.2.tar.bz2 \

--- a/5.026.000-64bit,threaded/Dockerfile
+++ b/5.026.000-64bit,threaded/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar.bz2 \
     && echo 'f21d66de84982175e95ad15fd8d0e22fed2cc2de7e4394f5d48dbe451be2f6f2 *perl-5.26.0.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.26.0.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.0.tar.bz2 \

--- a/5.026.000-64bit/Dockerfile
+++ b/5.026.000-64bit/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar.bz2 \
     && echo 'f21d66de84982175e95ad15fd8d0e22fed2cc2de7e4394f5d48dbe451be2f6f2 *perl-5.26.0.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xjf perl-5.26.0.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.0.tar.bz2 \

--- a/Releases.yaml
+++ b/Releases.yaml
@@ -1,58 +1,48 @@
 releases:
   - version: 5.8.9
     sha256:  1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79
-    pause:   NWCLARK
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.10.1
     sha256:  9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826
-    pause:   DAPM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.12.5
     sha256:  10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c
-    pause:   DOM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.14.4
     sha256:  eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745
-    pause:   DAPM
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.16.3
     sha256:  bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8
-    pause:   RJBS
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.18.4
     sha256:  1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5
-    pause:   RJBS
     extra_flags: "-A ccflags=-fwrapv"
     test_parallel: no
     buildpack_deps: jessie
 
   - version: 5.20.3
     sha256:  1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b
-    pause:   SHAY
 
   - version: 5.22.4
     sha256:  8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71
-    pause:   SHAY
 
   - version: 5.24.2
     sha256:  e28c8fa588c4227eb25350036b45d7b1b46d61bb3a2194ee09dc79be6ed0fd0f
-    pause:   SHAY
 
   - version: 5.26.0
     sha256:  f21d66de84982175e95ad15fd8d0e22fed2cc2de7e4394f5d48dbe451be2f6f2
-    pause:   XSAWYERX


### PR DESCRIPTION
We seem to be using www.cpan.org for getting the Perl tarballs for
patching with Devel::PatchPerl, yet in our generated Dockerfiles we are
using cpan.metacpan.org instead.  Since the former location is listed in
www.perl.org as the canonical Perl source location, let's base from that
as our single source of truth.

This also means we can depend less on finding which PAUSE account has
which Perl release, so let's remove that from the Releases.yaml as well.

