### PR TITLE
Adjust "./Configure" for wider architecture support

### DIFF
--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.b
     && tar --strip-components=1 -xjf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.b
     && tar --strip-components=1 -xjf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar
     && tar --strip-components=1 -xjf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar
     && tar --strip-components=1 -xjf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar
     && tar --strip-components=1 -xjf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar
     && tar --strip-components=1 -xjf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar
     && tar --strip-components=1 -xjf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar
     && tar --strip-components=1 -xjf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar
     && tar --strip-components=1 -xjf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar
     && tar --strip-components=1 -xjf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar
     && tar --strip-components=1 -xjf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar
     && tar --strip-components=1 -xjf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local -A ccflags=-fwrapv -des \
     && make -j$(nproc) \
     && make test_harness \
     && make install \

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar
     && tar --strip-components=1 -xjf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar
     && tar --strip-components=1 -xjf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar
     && tar --strip-components=1 -xjf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar
     && tar --strip-components=1 -xjf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.024.002-64bit,threaded/Dockerfile
+++ b/5.024.002-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar
     && tar --strip-components=1 -xjf perl-5.24.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.2.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.024.002-64bit/Dockerfile
+++ b/5.024.002-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.2.tar.bz2 -o perl-5.24.2.tar
     && tar --strip-components=1 -xjf perl-5.24.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.2.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.026.000-64bit,threaded/Dockerfile
+++ b/5.026.000-64bit,threaded/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar
     && tar --strip-components=1 -xjf perl-5.26.0.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.0.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Dusethreads -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Dusethreads -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/5.026.000-64bit/Dockerfile
+++ b/5.026.000-64bit/Dockerfile
@@ -9,7 +9,10 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.0.tar.bz2 -o perl-5.26.0.tar
     && tar --strip-components=1 -xjf perl-5.26.0.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.0.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure -Duse64bitall -Duseshrplib -Dvendorprefix=/usr/local  -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" -Duseshrplib -Dvendorprefix=/usr/local  -des \
     && make -j$(nproc) \
     && TEST_JOBS=$(nproc) make test_harness \
     && make install \

--- a/generate.pl
+++ b/generate.pl
@@ -41,8 +41,8 @@ my $common = join " ", qw{
 };
 
 my %builds = (
-  "64bit"          => "-Duse64bitall $common",
-  "64bit,threaded" => "-Dusethreads -Duse64bitall $common",
+  "64bit"          => "$common",
+  "64bit,threaded" => "-Dusethreads $common",
 );
 
 # sha256 taken from http://www.cpan.org/authors/id/M/MI/MIYAGAWA/CHECKSUMS
@@ -205,7 +205,10 @@ RUN curl -SL {{url}} -o perl-{{version}}.tar.bz2 \
     && tar --strip-components=1 -xjf perl-{{version}}.tar.bz2 -C /usr/src/perl \
     && rm perl-{{version}}.tar.bz2 \
     && cat *.patch | patch -p1 \
-    && ./Configure {{args}} {{extra_flags}} -des \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \
+    && archFlag="$([ "$archBits" = '64' ] && echo '-Duse64bitall' || echo '-Duse64bitint')" \
+    && ./Configure -Darchname="$gnuArch" "$archFlag" {{args}} {{extra_flags}} -des \
     && make -j$(nproc) \
     && {{test}} \
     && make install \


### PR DESCRIPTION
This builds on https://github.com/Perl/docker-perl/pull/38, and adds an appropriate `-Darchname` value for cross-building (arm32v7 builds on an arm64v8 kernel, i386 builds on an amd64 kernel, etc), and conditionally converts `-Duse64bitall` into `-Duse64bitint` (which is what Debian uses when compiling Perl).

> *** You have chosen a maximally 64-bit build,
> *** but your pointers are only 4 bytes wide.
> *** Please rerun Configure without -Duse64bitall.
> *** Since you have quads, you could possibly try with -Duse64bitint.

See also https://sources.debian.net/src/perl/stretch/debian/config.debian/#L115 and https://sources.debian.net/src/perl/stretch/debian/config.debian/#L130.

> ```
>     -Darchname=$host_gnu_type			\
> ...
>     -Duse64bitint                               \
> ```

I've personally tested (successfully) building `5.026.000-64bit/Dockerfile` on `arm32v7`, `arm64v8`, `i386`, `s390x`, and `ppc64le`.  I'm happy to perform further testing as desired.  This should really work fine on any of the architectures supported by `buildpack-deps:stretch` (`amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x`), although I haven't verified `arm32v5` directly (since it has no hardware floating point, and thus is usually really slow :sweat_smile:).