### PR TITLE
Reduces image size of resulting Docker Perl image

### DIFF
--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.b
 WORKDIR /root
 
 CMD ["perl5.8.9","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.8.9","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.008.009-64bit,threaded/Dockerfile
+++ b/5.008.009-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.b
 WORKDIR /root
 
 CMD ["perl5.8.9","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.8.9","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.008.009-64bit/Dockerfile
+++ b/5.008.009-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar
 WORKDIR /root
 
 CMD ["perl5.10.1","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.10.1","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.010.001-64bit,threaded/Dockerfile
+++ b/5.010.001-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar
 WORKDIR /root
 
 CMD ["perl5.10.1","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.10.1","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.010.001-64bit/Dockerfile
+++ b/5.010.001-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.12.5","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/5.012.005-64bit,threaded/Dockerfile
+++ b/5.012.005-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar
 WORKDIR /root
 
 CMD ["perl5.12.5","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.12.5","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/5.012.005-64bit/Dockerfile
+++ b/5.012.005-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar
 WORKDIR /root
 
 CMD ["perl5.12.5","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.14.4","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/5.014.004-64bit,threaded/Dockerfile
+++ b/5.014.004-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar
 WORKDIR /root
 
 CMD ["perl5.14.4","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.14.4","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/5.014.004-64bit/Dockerfile
+++ b/5.014.004-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar
 WORKDIR /root
 
 CMD ["perl5.14.4","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.16.3","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.016.003-64bit,threaded/Dockerfile
+++ b/5.016.003-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar
 WORKDIR /root
 
 CMD ["perl5.16.3","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.16.3","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.016.003-64bit/Dockerfile
+++ b/5.016.003-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar
 WORKDIR /root
 
 CMD ["perl5.16.3","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar
 WORKDIR /root
 
 CMD ["perl5.18.4","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/5.018.004-64bit,threaded/Dockerfile
+++ b/5.018.004-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.18.4","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:jessie as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar
 WORKDIR /root
 
 CMD ["perl5.18.4","-de0"]
+
+FROM debian:jessie-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/5.018.004-64bit/Dockerfile
+++ b/5.018.004-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.18.4","-de0"]
 FROM debian:jessie-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.20.3","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar
 WORKDIR /root
 
 CMD ["perl5.20.3","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.020.003-64bit,threaded/Dockerfile
+++ b/5.020.003-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.20.3","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar
 WORKDIR /root
 
 CMD ["perl5.20.3","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.020.003-64bit/Dockerfile
+++ b/5.020.003-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.22.4","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/5.022.004-64bit,threaded/Dockerfile
+++ b/5.022.004-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar
 WORKDIR /root
 
 CMD ["perl5.22.4","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.22.4","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/5.022.004-64bit/Dockerfile
+++ b/5.022.004-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar
 WORKDIR /root
 
 CMD ["perl5.22.4","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.024.004-64bit,threaded/Dockerfile
+++ b/5.024.004-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar
 WORKDIR /root
 
 CMD ["perl5.24.4","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.024.004-64bit,threaded/Dockerfile
+++ b/5.024.004-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.24.4","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.024.004-64bit,threaded/Dockerfile
+++ b/5.024.004-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/5.024.004-64bit/Dockerfile
+++ b/5.024.004-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar
 WORKDIR /root
 
 CMD ["perl5.24.4","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.024.004-64bit/Dockerfile
+++ b/5.024.004-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.24.4","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.024.004-64bit/Dockerfile
+++ b/5.024.004-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/5.026.002-64bit,threaded/Dockerfile
+++ b/5.026.002-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
     && echo '3f6a6b5bbd43016e5211e24b6631ea84216dd300216a2293b41c9195032f3e81 *perl-5.26.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.2.tar.bz2 \

--- a/5.026.002-64bit,threaded/Dockerfile
+++ b/5.026.002-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
     && echo '3f6a6b5bbd43016e5211e24b6631ea84216dd300216a2293b41c9195032f3e81 *perl-5.26.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.2.tar.bz2 \
@@ -23,5 +24,11 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7044* /tmp/*
 
 WORKDIR /root
+
+CMD ["perl5.26.2","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
 
 CMD ["perl5.26.2","-de0"]

--- a/5.026.002-64bit,threaded/Dockerfile
+++ b/5.026.002-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.26.2","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.026.002-64bit/Dockerfile
+++ b/5.026.002-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
     && echo '3f6a6b5bbd43016e5211e24b6631ea84216dd300216a2293b41c9195032f3e81 *perl-5.26.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.2.tar.bz2 \

--- a/5.026.002-64bit/Dockerfile
+++ b/5.026.002-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar.bz2 \
     && echo '3f6a6b5bbd43016e5211e24b6631ea84216dd300216a2293b41c9195032f3e81 *perl-5.26.2.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.2.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.2.tar.bz2 \
@@ -23,5 +24,11 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.26.2.tar.bz2 -o perl-5.26.2.tar
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7044* /tmp/*
 
 WORKDIR /root
+
+CMD ["perl5.26.2","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
 
 CMD ["perl5.26.2","-de0"]

--- a/5.026.002-64bit/Dockerfile
+++ b/5.026.002-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.26.2","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.028.000-64bit,threaded/Dockerfile
+++ b/5.028.000-64bit,threaded/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.28.0","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.028.000-64bit,threaded/Dockerfile
+++ b/5.028.000-64bit,threaded/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
     && echo '059b3cb69970d8c8c5964caced0335b4af34ac990c8e61f7e3f90cd1c2d11e49 *perl-5.28.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.0.tar.xz -C /usr/src/perl \
     && rm perl-5.28.0.tar.xz \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.
 WORKDIR /root
 
 CMD ["perl5.28.0","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.028.000-64bit,threaded/Dockerfile
+++ b/5.028.000-64bit,threaded/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
     && echo '059b3cb69970d8c8c5964caced0335b4af34ac990c8e61f7e3f90cd1c2d11e49 *perl-5.28.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.0.tar.xz -C /usr/src/perl \
     && rm perl-5.28.0.tar.xz \

--- a/5.028.000-64bit/Dockerfile
+++ b/5.028.000-64bit/Dockerfile
@@ -30,5 +30,6 @@ CMD ["perl5.28.0","-de0"]
 FROM debian:stretch-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]

--- a/5.028.000-64bit/Dockerfile
+++ b/5.028.000-64bit/Dockerfile
@@ -1,10 +1,11 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:stretch as build
 LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@cpan.org>"
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
+RUN apt-get update && apt-get install --no-install-recommends less \
+    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
     && echo '059b3cb69970d8c8c5964caced0335b4af34ac990c8e61f7e3f90cd1c2d11e49 *perl-5.28.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.0.tar.xz -C /usr/src/perl \
     && rm perl-5.28.0.tar.xz \
@@ -25,3 +26,9 @@ RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.
 WORKDIR /root
 
 CMD ["perl5.28.0","-de0"]
+
+FROM debian:stretch-slim as runtime
+WORKDIR /root
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+CMD ["perl5.26.2","-de0"]

--- a/5.028.000-64bit/Dockerfile
+++ b/5.028.000-64bit/Dockerfile
@@ -4,8 +4,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
+RUN curl -SL https://www.cpan.org/src/5.0/perl-5.28.0.tar.xz -o perl-5.28.0.tar.xz \
     && echo '059b3cb69970d8c8c5964caced0335b4af34ac990c8e61f7e3f90cd1c2d11e49 *perl-5.28.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.0.tar.xz -C /usr/src/perl \
     && rm perl-5.28.0.tar.xz \

--- a/generate.pl
+++ b/generate.pl
@@ -201,8 +201,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-RUN apt-get update && apt-get install --no-install-recommends less \
-    && curl -SL {{url}} -o perl-{{version}}.tar.{{type}} \
+RUN curl -SL {{url}} -o perl-{{version}}.tar.{{type}} \
     && echo '{{sha256}} *perl-{{version}}.tar.{{type}}' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-{{version}}.tar.{{type}} -C /usr/src/perl \
     && rm perl-{{version}}.tar.{{type}} \

--- a/generate.pl
+++ b/generate.pl
@@ -227,5 +227,6 @@ CMD ["perl{{version}}","-de0"]
 FROM debian:{{_tag}}-slim as runtime
 WORKDIR /root
 COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+COPY --from=build /usr/local/bin /usr/local/bin/
 
 CMD ["perl5.26.2","-de0"]


### PR DESCRIPTION
By using a multi-stage strategy the resulting image can be brought down
to ~100MB instead of ~800MB.

By running the following commands we can create two images, a build
image and a slim image:

    docker build -t perl:<tag> --target build .

    docker build -t perl:<tag>-slim .

This can be further optimized by only installing cpanm in another stage.
It is a nice to have while building an image, but you don't need cpanm
on a running container.