### PR TITLE
Fix bug where git diff always differs with upstream

### DIFF
--- a/generate.pl
+++ b/generate.pl
@@ -133,7 +133,7 @@ for my $release (@{$config->{releases}}) {
     die "Couldn't create a temp git repo for $release->{version}" if $? != 0;
     Devel::PatchPerl->patch_source($release->{version}, $dir);
     $patch = qx{
-      cd $dir && git diff
+      cd $dir && git -c 'diff.mnemonicprefix=false' diff
     };
     die "Couldn't create a Devel::PatchPerl patch for $release->{version}" if $? != 0;
   }


### PR DESCRIPTION
When running generate I get a lot of differences in DevelPatchPerl.patch
because git's `diff.mnemonicprefix` is set to `true`. To mitigate this, use `git
diff --src-dir=a/ --dst-dir=b/` so everything is the same as upstream
for everyone.