### PR TITLE
Enable CI via GitHub Actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,35 @@
+name: Build and test latest supported Perls
+
+env:
+  VERSION: 5.030.001
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+    pull_request:
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [ 'main', 'slim', 'main,threaded', 'slim,threaded' ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Clone docker-library/official-images (for testing)
+        run: |
+          git clone --depth 1 --single-branch https://github.com/docker-library/official-images.git
+      - name: Build image
+        run: |
+          docker version
+          docker build --no-cache -t perl:$VERSION $VERSION-${{ matrix.variant }}-buster
+      - name: Inspect image creation and tag time
+        run: |
+          docker image inspect --format \'{{.Created}}\' perl:$VERSION
+          docker image inspect --format \'{{.Metadata.LastTagTime}}\' perl:$VERSION
+      - name: Run tests
+        run: |
+          ./official-images/test/run.sh perl:$VERSION

--- a/.github/workflows/generate-dockerfiles-patches.yml
+++ b/.github/workflows/generate-dockerfiles-patches.yml
@@ -1,0 +1,31 @@
+name: Generate Dockerfiles/patches
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+    pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up git user name and email
+        run: |
+          git config --global user.email "test@github-actions"
+          git config --global user.name "GitHub Actions"
+      - uses: actions/checkout@master
+      - name: Install system perl and cpanm
+        run: |
+          sudo apt-get install --no-install-recommends -y perl cpanminus
+      - name: Install dependencies
+        run: |
+          cpanm --quiet --installdeps --notest -L local .
+      - name: Generate Dockerfiles/patches
+        run: |
+          perl -Ilocal/lib/perl5 ./generate.pl
+      - name: Show diffstat (if any)
+        run: |
+          git --no-pager diff --stat HEAD


### PR DESCRIPTION
Implement #68 using the GitHub Actions feature to test both Docker image builds for our Perl images and test the toolchain for generating Dockerfiles/patches.