### PR TITLE
Fix Time-Local test failure upon year 2020 for 5.26 - 5.28

### DIFF
--- a/5.026.003-main,threaded-buster/Fix-Time-Local-tests.patch
+++ b/5.026.003-main,threaded-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-main,threaded-stretch/Fix-Time-Local-tests.patch
+++ b/5.026.003-main,threaded-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-main-buster/Fix-Time-Local-tests.patch
+++ b/5.026.003-main-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-main-stretch/Fix-Time-Local-tests.patch
+++ b/5.026.003-main-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-slim,threaded-buster/Fix-Time-Local-tests.patch
+++ b/5.026.003-slim,threaded-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-slim,threaded-stretch/Fix-Time-Local-tests.patch
+++ b/5.026.003-slim,threaded-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-slim-buster/Fix-Time-Local-tests.patch
+++ b/5.026.003-slim-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.026.003-slim-stretch/Fix-Time-Local-tests.patch
+++ b/5.026.003-slim-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-main,threaded-buster/Fix-Time-Local-tests.patch
+++ b/5.028.002-main,threaded-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-main,threaded-stretch/Fix-Time-Local-tests.patch
+++ b/5.028.002-main,threaded-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-main-buster/Fix-Time-Local-tests.patch
+++ b/5.028.002-main-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-main-stretch/Fix-Time-Local-tests.patch
+++ b/5.028.002-main-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-slim,threaded-buster/Fix-Time-Local-tests.patch
+++ b/5.028.002-slim,threaded-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-slim,threaded-stretch/Fix-Time-Local-tests.patch
+++ b/5.028.002-slim,threaded-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-slim-buster/Fix-Time-Local-tests.patch
+++ b/5.028.002-slim-buster/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/5.028.002-slim-stretch/Fix-Time-Local-tests.patch
+++ b/5.028.002-slim-stretch/Fix-Time-Local-tests.patch
@@ -1,0 +1,67 @@
+From c4c733988fd2012cf517c021bb31ec13097b2d48 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Fri, 16 Mar 2018 11:44:01 +0100
+Subject: [PATCH] Fix Time::Local tests
+
+in 2020, year 70 changes its meaning to 2070
+so we do what man Time::Local recommends and use 4-digit years
+---
+ cpan/Time-Local/t/Local.t | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/cpan/Time-Local/t/Local.t b/cpan/Time-Local/t/Local.t
+index 634139695f..e28c6d2129 100644
+--- a/cpan/Time-Local/t/Local.t
++++ b/cpan/Time-Local/t/Local.t
+@@ -96,7 +96,7 @@ SKIP: {
+ 
+         # Test timelocal()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timelocal( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = localtime($time);
+@@ -111,7 +111,7 @@ SKIP: {
+ 
+         # Test timegm()
+         {
+-            my $year_in = $year < 70 ? $year + 1900 : $year;
++            my $year_in = $year + 1900;
+             my $time = timegm( $sec, $min, $hour, $mday, $mon, $year_in );
+ 
+             my ( $s, $m, $h, $D, $M, $Y ) = gmtime($time);
+@@ -128,7 +128,6 @@ SKIP: {
+ 
+ for (@bad_time) {
+     my ( $year, $mon, $mday, $hour, $min, $sec ) = @$_;
+-    $year -= 1900;
+     $mon--;
+ 
+     eval { timegm( $sec, $min, $hour, $mday, $mon, $year ) };
+@@ -138,19 +137,19 @@ for (@bad_time) {
+ 
+ {
+     is(
+-        timelocal( 0, 0, 1, 1, 0, 90 ) - timelocal( 0, 0, 0, 1, 0, 90 ), 3600,
++        timelocal( 0, 0, 1, 1, 0, 1990 ) - timelocal( 0, 0, 0, 1, 0, 1990 ), 3600,
+         'one hour difference between two calls to timelocal'
+     );
+ 
+     is(
+-        timelocal( 1, 2, 3, 1, 0, 100 ) - timelocal( 1, 2, 3, 31, 11, 99 ),
++        timelocal( 1, 2, 3, 1, 0, 2000 ) - timelocal( 1, 2, 3, 31, 11, 1999 ),
+         24 * 3600,
+         'one day difference between two calls to timelocal'
+     );
+ 
+     # Diff beween Jan 1, 1980 and Mar 1, 1980 = (31 + 29 = 60 days)
+     is(
+-        timegm( 0, 0, 0, 1, 2, 80 ) - timegm( 0, 0, 0, 1, 0, 80 ),
++        timegm( 0, 0, 0, 1, 2, 1980 ) - timegm( 0, 0, 0, 1, 0, 1980 ),
+         60 * 24 * 3600,
+         '60 day difference between two calls to timegm'
+     );
+-- 
+2.13.6
+

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Devel::PatchPerl';
 requires 'YAML::XS';
+requires 'version', '0.77';
 
 on 'develop' => sub {
     requires 'Perl::Tidy';

--- a/generate.pl
+++ b/generate.pl
@@ -6,6 +6,8 @@ use YAML::XS;
 use Devel::PatchPerl;
 use LWP::Simple;
 
+use version 0.77;
+
 sub die_with_sample {
   die <<EOF;
 
@@ -79,6 +81,9 @@ my $template = do {
   local $/;
   <DATA>;
 };
+
+# fetch Time-Local test patch for fixing failures upon entering year 2020
+my $time_local_patch = get 'https://rt.cpan.org/Public/Ticket/Attachment/1776857/956088/0001-Fix-Time-Local-tests.patch';
 
 my %builds;
 
@@ -177,6 +182,14 @@ for my $release (@{$config->{releases}}) {
       {
         open my $fh, ">", "$dir/DevelPatchPerl.patch";
         print $fh $patch;
+      }
+
+      # Install additional patch for Time::Local on perls between 5.26 to 5.30
+      if ( version->parse("v$release->{version}") >= version->parse('v5.26.0')
+        && version->parse("v$release->{version}") < version->parse('v5.30.0'))
+      {
+        open my $fh, '>', "$dir/Fix-Time-Local-tests.patch";
+        print $fh $time_local_patch;
       }
 
       if (defined $release->{test_parallel} && $release->{test_parallel} eq "no") {


### PR DESCRIPTION
Ref. #76 (not quite fixes it for all perls yet, prioritizing 5.28 which is the current supported version affected.)