### PR TITLE
Restore GDBM_File test skip for failing 5.28.3 builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,8 +1,5 @@
 name: Build and test latest supported Perls
 
-env:
-  VERSION: 5.030.003
-
 on: [push, pull_request]
 
 jobs:
@@ -11,6 +8,7 @@ jobs:
     strategy:
       matrix:
         variant: [ 'main', 'slim', 'main,threaded', 'slim,threaded' ]
+        perl-version: [ '5.030.003', '5.028.003' ]
     steps:
       - uses: actions/checkout@master
       - name: Clone docker-library/official-images (for testing)
@@ -19,11 +17,11 @@ jobs:
       - name: Build image
         run: |
           docker version
-          docker build --no-cache -t perl:$VERSION $VERSION-${{ matrix.variant }}-buster
+          docker build --no-cache -t perl:${{ matrix.perl-version }} ${{ matrix.perl-version }}-${{ matrix.variant }}-buster
       - name: Inspect image creation and tag time
         run: |
-          docker image inspect --format \'{{.Created}}\' perl:$VERSION
-          docker image inspect --format \'{{.Metadata.LastTagTime}}\' perl:$VERSION
+          docker image inspect --format \'{{.Created}}\' perl:${{ matrix.perl-version }}
+          docker image inspect --format \'{{.Metadata.LastTagTime}}\' perl:${{ matrix.perl-version }}
       - name: Run tests
         run: |
-          ./official-images/test/run.sh perl:$VERSION
+          ./official-images/test/run.sh perl:${{ matrix.perl-version }}

--- a/5.028.003-main,threaded-buster/rt-perl-133295.patch
+++ b/5.028.003-main,threaded-buster/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-main,threaded-stretch/rt-perl-133295.patch
+++ b/5.028.003-main,threaded-stretch/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-main-buster/rt-perl-133295.patch
+++ b/5.028.003-main-buster/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-main-stretch/rt-perl-133295.patch
+++ b/5.028.003-main-stretch/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-slim,threaded-buster/rt-perl-133295.patch
+++ b/5.028.003-slim,threaded-buster/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-slim,threaded-stretch/rt-perl-133295.patch
+++ b/5.028.003-slim,threaded-stretch/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-slim-buster/rt-perl-133295.patch
+++ b/5.028.003-slim-buster/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;

--- a/5.028.003-slim-stretch/rt-perl-133295.patch
+++ b/5.028.003-slim-stretch/rt-perl-133295.patch
@@ -1,0 +1,69 @@
+From 0d9e812de5885109532ec8bf484f165213ab97cb Mon Sep 17 00:00:00 2001
+From: David Mitchell <davem@iabyn.com>
+Date: Fri, 14 Dec 2018 16:54:42 +0000
+Subject: [PATCH] ext/GDBM_File/t/fatal.t: handle non-fatality
+
+This script is supposed to exercise the error handling callback
+mechanism in gdbm, by triggering an error by surreptitiously closing
+the file handle which gdbm has opened.
+
+However, this doesn't trigger an error in newer releases of the gdbm
+library, which uses mmap() rather than write() etc. In fact I can't see
+any way of triggering an error: so just skip the relevant tests if we
+can't trigger a failure.
+---
+ ext/GDBM_File/t/fatal.t | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+diff --git a/ext/GDBM_File/t/fatal.t b/ext/GDBM_File/t/fatal.t
+index 3ba66be598c..159916901a9 100644
+--- a/ext/GDBM_File/t/fatal.t
++++ b/ext/GDBM_File/t/fatal.t
+@@ -1,4 +1,12 @@
+ #!./perl -w
++#
++# Exercise the error handling callback mechanism in gdbm.
++#
++# Try to trigger an error by surreptitiously closing the file handle which
++# gdbm has opened.  Note that this won't trigger an error in newer
++# releases of the gdbm library, which uses mmap() rather than write() etc:
++# so skip in that case.
++
+ use strict;
+ 
+ use Test::More;
+@@ -34,16 +42,25 @@ isnt((open $fh, "<&=$fileno"), undef, "dup fileno $fileno")
+     or diag("\$! = $!");
+ isnt(close $fh, undef,
+      "close fileno $fileno, out from underneath the GDBM_File");
+-is(eval {
++
++# store some data to a closed file handle
++
++my $res = eval {
+     $h{Perl} = 'Rules';
+     untie %h;
+-    1;
+-}, undef, 'Trapped error when attempting to write to knobbled GDBM_File');
+-
+-# Observed "File write error" and "lseek error" from two different systems.
+-# So there might be more variants. Important part was that we trapped the error
+-# via croak.
+-like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
+-     'expected error message from GDBM_File');
++    99;
++};
++
++SKIP: {
++    skip "Can't tigger failure", 2 if $res == 99;
++
++    is $res, undef, "eval should return undef";
++
++    # Observed "File write error" and "lseek error" from two different
++    # systems.  So there might be more variants. Important part was that
++    # we trapped the error # via croak.
++    like($@, qr/ at .*\bfatal\.t line \d+\.\n\z/,
++         'expected error message from GDBM_File');
++}
+ 
+ unlink <fatal_dbmx*>;


### PR DESCRIPTION
Builds for 5.28.3 was failing on https://github.com/docker-library/official-images/pull/8122 due to missing `rt-perl-133295.patch` (commit 01044791941b91f99e970c3f1256d9dc0daee5e4 which was in 5.28.2, and something Devel::PatchPerl isn't really responsible for.)  Restore that patch, and try to ensure we build current and previous supported Perls here before taking it to official-images.