### PR TITLE
add LWP::Simple to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Devel::PatchPerl';
 requires 'YAML::XS';
+requires 'LWP::Simple';
 
 on 'develop' => sub {
     requires 'Perl::Tidy';


### PR DESCRIPTION
generate.pl uses LWP::Simple, which is not a core module, so I included it in cpanfile
https://github.com/AnaTofuZ/docker-perl/blob/c02e3bce8af52f3cfb070c376d15f39b657759a2/generate.pl#L7