### PR TITLE
Revert "Configure cpanm to install over HTTPS"

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -48,13 +48,8 @@ jobs:
           img="perl:${dir//,/-}"
           docker image inspect --format '{{.Created}}' "$img"
           docker image inspect --format '{{.Metadata.LastTagTime}}' "$img"
-      - name: Run tests from docker-library/official-images
+      - name: Run tests
         run: |
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           ./official-images/test/run.sh "$img"
-      - name: Run cpanm install test
-        run: |
-          dir='${{ matrix.directory }}'
-          img="perl:${dir//,/-}"
-          docker run "$img" cpanm -v Mojolicious

--- a/5.032.001-main,threaded-bullseye/Dockerfile
+++ b/5.032.001-main,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \

--- a/5.032.001-main,threaded-buster/Dockerfile
+++ b/5.032.001-main,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \

--- a/5.032.001-main-bullseye/Dockerfile
+++ b/5.032.001-main-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \

--- a/5.032.001-main-buster/Dockerfile
+++ b/5.032.001-main-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \

--- a/5.032.001-slim,threaded-bullseye/Dockerfile
+++ b/5.032.001-slim,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim,threaded-buster/Dockerfile
+++ b/5.032.001-slim,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-bullseye/Dockerfile
+++ b/5.032.001-slim-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-buster/Dockerfile
+++ b/5.032.001-slim-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-main,threaded-bullseye/Dockerfile
+++ b/5.034.001-main,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \

--- a/5.034.001-main,threaded-buster/Dockerfile
+++ b/5.034.001-main,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \

--- a/5.034.001-main-bullseye/Dockerfile
+++ b/5.034.001-main-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \

--- a/5.034.001-main-buster/Dockerfile
+++ b/5.034.001-main-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \

--- a/5.034.001-slim,threaded-bullseye/Dockerfile
+++ b/5.034.001-slim,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim,threaded-buster/Dockerfile
+++ b/5.034.001-slim,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-bullseye/Dockerfile
+++ b/5.034.001-slim-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-buster/Dockerfile
+++ b/5.034.001-slim-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-main,threaded-bullseye/Dockerfile
+++ b/5.036.000-main,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \

--- a/5.036.000-main,threaded-buster/Dockerfile
+++ b/5.036.000-main,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \

--- a/5.036.000-main-bullseye/Dockerfile
+++ b/5.036.000-main-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \

--- a/5.036.000-main-buster/Dockerfile
+++ b/5.036.000-main-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN true \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \

--- a/5.036.000-slim,threaded-bullseye/Dockerfile
+++ b/5.036.000-slim,threaded-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim,threaded-buster/Dockerfile
+++ b/5.036.000-slim,threaded-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-bullseye/Dockerfile
+++ b/5.036.000-slim-bullseye/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-buster/Dockerfile
+++ b/5.036.000-slim-buster/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        bzip2 \
@@ -43,7 +41,7 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="ca-certificates curl make netbase" \
+    && savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/generate.pl
+++ b/generate.pl
@@ -61,7 +61,7 @@ EOF
 chomp $docker_slim_run_install;
 
 my $docker_slim_run_purge = <<'EOF';
-savedPackages="ca-certificates curl make netbase" \
+savedPackages="make netbase" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
@@ -279,8 +279,6 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 
 COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
-
-ENV PERL_CPANM_OPT="--from https://www.cpan.org"
 
 RUN {{docker_slim_run_install}} \
     && curl -SL {{url}} -o perl-{{version}}.tar.{{type}} \


### PR DESCRIPTION
Reverts Perl/docker-perl#115, fixes #116 - need to revisit other options to fetch and verify CPAN module dists securely in another PR.