### PR TITLE
Adds out of the box SSL support w/ IO::Socket::SSL

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -53,3 +53,4 @@ jobs:
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           ./official-images/test/run.sh "$img"
+          docker run "$img" perl -MHTTP::Tiny -E 'if (HTTP::Tiny->new->get("https://github.com")->{status} == 200) { exit 0 } exit 1'

--- a/5.032.001-main,threaded-bullseye/Dockerfile
+++ b/5.032.001-main,threaded-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main,threaded-buster/Dockerfile
+++ b/5.032.001-main,threaded-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main-bullseye/Dockerfile
+++ b/5.032.001-main-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main-buster/Dockerfile
+++ b/5.032.001-main-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-slim,threaded-bullseye/Dockerfile
+++ b/5.032.001-slim,threaded-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim,threaded-buster/Dockerfile
+++ b/5.032.001-slim,threaded-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-bullseye/Dockerfile
+++ b/5.032.001-slim-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-buster/Dockerfile
+++ b/5.032.001-slim-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-main,threaded-bullseye/Dockerfile
+++ b/5.034.001-main,threaded-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main,threaded-buster/Dockerfile
+++ b/5.034.001-main,threaded-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main-bullseye/Dockerfile
+++ b/5.034.001-main-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main-buster/Dockerfile
+++ b/5.034.001-main-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-slim,threaded-bullseye/Dockerfile
+++ b/5.034.001-slim,threaded-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.34.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim,threaded-buster/Dockerfile
+++ b/5.034.001-slim,threaded-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.34.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-bullseye/Dockerfile
+++ b/5.034.001-slim-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.34.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-buster/Dockerfile
+++ b/5.034.001-slim-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.34.1.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-main,threaded-bullseye/Dockerfile
+++ b/5.036.000-main,threaded-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main,threaded-buster/Dockerfile
+++ b/5.036.000-main,threaded-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main-bullseye/Dockerfile
+++ b/5.036.000-main-bullseye/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main-buster/Dockerfile
+++ b/5.036.000-main-buster/Dockerfile
@@ -21,6 +21,7 @@ RUN true \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-slim,threaded-bullseye/Dockerfile
+++ b/5.036.000-slim,threaded-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.36.0.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim,threaded-buster/Dockerfile
+++ b/5.036.000-slim,threaded-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.36.0.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-bullseye/Dockerfile
+++ b/5.036.000-slim-bullseye/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.36.0.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-buster/Dockerfile
+++ b/5.036.000-slim-buster/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
+       lib32z1-dev \
+       libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.36.0.tar.xz -C /usr/src/perl \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && curl -LO https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7046.tar.gz \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
-    && savedPackages="make netbase" \
+    && cpanm IO::Socket::SSL \
+    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/generate.pl
+++ b/generate.pl
@@ -56,12 +56,14 @@ apt-get update \
        patch \
        # procps \
        # zlib1g-dev \
-       xz-utils
+       xz-utils \
+       lib32z1-dev \
+       libssl-dev
 EOF
 chomp $docker_slim_run_install;
 
 my $docker_slim_run_purge = <<'EOF';
-savedPackages="make netbase" \
+savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
@@ -297,6 +299,7 @@ RUN {{docker_slim_run_install}} \
     && curl -LO {{cpanm_dist_url}} \
     && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum -c - \
     && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} && perl bin/cpanm . && cd /root \
+    && cpanm IO::Socket::SSL \
     && {{docker_slim_run_purge}} \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/*
 


### PR DESCRIPTION
I was reading domm's blogpost[^1] and domm has some (imo) valid points in using
the slim image and not have SSL support out of the box. Because p5p hasn't made
a decision yet on how to get out of the box SSL support[^2] we are somewhat
left with our own solutions.
Since we now have a discussion about using cpm and we want to use https
endpoints to install packages it would made sense to have the images support
SSL by default as well. This is an attempt to do so.

[^1]: https://domm.plix.at/perl/2022_06_dockerfile_for_perl_5_36.html
[^2]: https://www.nntp.perl.org/group/perl.perl5.porters/2021/11/msg261979.html

The original commit message:

The new Dockerfiles preinstalls IO::Socket::SSL with its dependencies to give
users out of the box SSL support. For slim builds we also keep the lib32z1-dev
libssl-dev packages so when people run `cpanm Net::SSLeay` and it can be
upgraded it won't cause issues.

It slightly increases the resulting image from 144MB to 197MB

Signed-off-by: Wesley Schwengle <wesley@opperschaap.net>