### PR TITLE
Add App::cpm and fix slim builds for non-x86{,_64}

### DIFF
--- a/5.032.001-main,threaded-bullseye/Dockerfile
+++ b/5.032.001-main,threaded-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main,threaded-buster/Dockerfile
+++ b/5.032.001-main,threaded-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main-bullseye/Dockerfile
+++ b/5.032.001-main-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-main-buster/Dockerfile
+++ b/5.032.001-main-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.032.001-slim,threaded-bullseye/Dockerfile
+++ b/5.032.001-slim,threaded-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim,threaded-buster/Dockerfile
+++ b/5.032.001-slim,threaded-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-bullseye/Dockerfile
+++ b/5.032.001-slim-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.032.001-slim-buster/Dockerfile
+++ b/5.032.001-slim-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-main,threaded-bullseye/Dockerfile
+++ b/5.034.001-main,threaded-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main,threaded-buster/Dockerfile
+++ b/5.034.001-main,threaded-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main-bullseye/Dockerfile
+++ b/5.034.001-main-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-main-buster/Dockerfile
+++ b/5.034.001-main-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.034.001-slim,threaded-bullseye/Dockerfile
+++ b/5.034.001-slim,threaded-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim,threaded-buster/Dockerfile
+++ b/5.034.001-slim,threaded-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-bullseye/Dockerfile
+++ b/5.034.001-slim-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.034.001-slim-buster/Dockerfile
+++ b/5.034.001-slim-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.34.1.tar.xz -o perl-5.34.1.tar.xz \
     && echo '6d52cf833ff1af27bb5e986870a2c30cec73c044b41e3458cd991f94374039f7 *perl-5.34.1.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-main,threaded-bullseye/Dockerfile
+++ b/5.036.000-main,threaded-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main,threaded-buster/Dockerfile
+++ b/5.036.000-main,threaded-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main-bullseye/Dockerfile
+++ b/5.036.000-main-bullseye/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-main-buster/Dockerfile
+++ b/5.036.000-main-buster/Dockerfile
@@ -22,6 +22,7 @@ RUN true \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && true \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7046* /tmp/*
 

--- a/5.036.000-slim,threaded-bullseye/Dockerfile
+++ b/5.036.000-slim,threaded-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim,threaded-buster/Dockerfile
+++ b/5.036.000-slim,threaded-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-bullseye/Dockerfile
+++ b/5.036.000-slim-bullseye/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/5.036.000-slim-buster/Dockerfile
+++ b/5.036.000-slim-buster/Dockerfile
@@ -23,9 +23,8 @@ RUN apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev \
     && curl -SL https://www.cpan.org/src/5.0/perl-5.36.0.tar.xz -o perl-5.36.0.tar.xz \
     && echo '0f386dccbee8e26286404b2cca144e1005be65477979beb9b1ba272d4819bcf0 *perl-5.36.0.tar.xz' | sha256sum -c - \
@@ -44,7 +43,8 @@ RUN apt-get update \
     && echo '3e8c9d9b44a7348f9acc917163dbfc15bd5ea72501492cea3a35b346440ff862 *App-cpanminus-1.7046.tar.gz' | sha256sum -c - \
     && tar -xzf App-cpanminus-1.7046.tar.gz && cd App-cpanminus-1.7046 && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
-    && savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
+    && savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/generate.pl
+++ b/generate.pl
@@ -55,15 +55,14 @@ apt-get update \
        netbase \
        patch \
        # procps \
-       # zlib1g-dev \
+       zlib1g-dev \
        xz-utils \
-       lib32z1-dev \
        libssl-dev
 EOF
 chomp $docker_slim_run_install;
 
 my $docker_slim_run_purge = <<'EOF';
-savedPackages="ca-certificates make netbase lib32z1-dev libssl-dev" \
+savedPackages="ca-certificates make netbase zlib1g-dev libssl-dev" \
     && apt-mark auto '.*' > /dev/null \
     && apt-mark manual $savedPackages \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/generate.pl
+++ b/generate.pl
@@ -300,6 +300,7 @@ RUN {{docker_slim_run_install}} \
     && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum -c - \
     && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} && perl bin/cpanm . && cd /root \
     && cpanm IO::Socket::SSL \
+    && cd /usr/local/bin && curl -LO https://raw.githubusercontent.com/skaji/cpm/0.997011/cpm && chmod +x cpm \
     && {{docker_slim_run_purge}} \
     && rm -fr ./cpanm /root/.cpanm /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/*
 


### PR DESCRIPTION
This adds a prebuilt version of https://metacpan.org/dist/App-cpm as an alternative CPAN module installer with full support for HTTPS sources (among other features such as described in https://metacpan.org/pod/App::cpm::Tutorial.)

Fixes #50.

This also includes a small fix for slim builds on non-x86 archs.