### PR TITLE
FIX: tar's a option does not exist in bsd

### DIFF
--- a/generate.pl
+++ b/generate.pl
@@ -130,7 +130,7 @@ for my $release (@{$config->{releases}}) {
     qx{rm -fR $dir};
     mkdir $dir or die "Couldn't create $dir";
     qx{
-      tar -C "downloads" -axf $dir.tar.$release->{type} &&\
+      tar -C "downloads" -xf $dir.tar.$release->{type} &&\
       cd $dir &&\
       find . -exec chmod u+w {} + &&\
       git init &&\


### PR DESCRIPTION
I am using macOS (BSD).
When I run generate.pl, I get the following error.

`tar: Option -a is not permitted in mode -x`

This is because BSD tar does not have the a option. Fortunately, GNU tar works without the a option, so I removed it so that it works with both.