### PR TITLE
Change WORKDIR from / to /usr/src/app

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -68,3 +68,13 @@ jobs:
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           docker run "$img" cpm install -v Mojolicious
+      - name: COPY all to default WORKDIR
+        run: |
+          dir='${{ matrix.directory }}'
+          img="perl:${dir//,/-}"
+          mkdir -p test/lib
+          cat <<EOF >Dockerfile
+          FROM $img
+          COPY . .
+          EOF
+          docker build -f Dockerfile test

--- a/5.034.001-main,threaded-bullseye/Dockerfile
+++ b/5.034.001-main,threaded-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-main,threaded-buster/Dockerfile
+++ b/5.034.001-main,threaded-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-main-bullseye/Dockerfile
+++ b/5.034.001-main-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-main-buster/Dockerfile
+++ b/5.034.001-main-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-slim,threaded-bullseye/Dockerfile
+++ b/5.034.001-slim,threaded-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-slim,threaded-buster/Dockerfile
+++ b/5.034.001-slim,threaded-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-slim-bullseye/Dockerfile
+++ b/5.034.001-slim-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.034.001-slim-buster/Dockerfile
+++ b/5.034.001-slim-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.34.1","-de0"]

--- a/5.036.001-main,threaded-bookworm/Dockerfile
+++ b/5.036.001-main,threaded-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-main,threaded-bullseye/Dockerfile
+++ b/5.036.001-main,threaded-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-main,threaded-buster/Dockerfile
+++ b/5.036.001-main,threaded-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-main-bookworm/Dockerfile
+++ b/5.036.001-main-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-main-bullseye/Dockerfile
+++ b/5.036.001-main-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-main-buster/Dockerfile
+++ b/5.036.001-main-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim,threaded-bookworm/Dockerfile
+++ b/5.036.001-slim,threaded-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim,threaded-bullseye/Dockerfile
+++ b/5.036.001-slim,threaded-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim,threaded-buster/Dockerfile
+++ b/5.036.001-slim,threaded-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim-bookworm/Dockerfile
+++ b/5.036.001-slim-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim-bullseye/Dockerfile
+++ b/5.036.001-slim-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.036.001-slim-buster/Dockerfile
+++ b/5.036.001-slim-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.36.1","-de0"]

--- a/5.038.000-main,threaded-bookworm/Dockerfile
+++ b/5.038.000-main,threaded-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-main,threaded-bullseye/Dockerfile
+++ b/5.038.000-main,threaded-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-main,threaded-buster/Dockerfile
+++ b/5.038.000-main,threaded-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-main-bookworm/Dockerfile
+++ b/5.038.000-main-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-main-bullseye/Dockerfile
+++ b/5.038.000-main-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-main-buster/Dockerfile
+++ b/5.038.000-main-buster/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim,threaded-bookworm/Dockerfile
+++ b/5.038.000-slim,threaded-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim,threaded-bullseye/Dockerfile
+++ b/5.038.000-slim,threaded-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim,threaded-buster/Dockerfile
+++ b/5.038.000-slim,threaded-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim-bookworm/Dockerfile
+++ b/5.038.000-slim-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim-bullseye/Dockerfile
+++ b/5.038.000-slim-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.038.000-slim-buster/Dockerfile
+++ b/5.038.000-slim-buster/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.38.0","-de0"]

--- a/5.039.001-main,threaded-bookworm/Dockerfile
+++ b/5.039.001-main,threaded-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-main,threaded-bullseye/Dockerfile
+++ b/5.039.001-main,threaded-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-main-bookworm/Dockerfile
+++ b/5.039.001-main-bookworm/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-main-bullseye/Dockerfile
+++ b/5.039.001-main-bullseye/Dockerfile
@@ -30,6 +30,6 @@ RUN true \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-slim,threaded-bookworm/Dockerfile
+++ b/5.039.001-slim,threaded-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-slim,threaded-bullseye/Dockerfile
+++ b/5.039.001-slim,threaded-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-slim-bookworm/Dockerfile
+++ b/5.039.001-slim-bookworm/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/5.039.001-slim-bullseye/Dockerfile
+++ b/5.039.001-slim-bullseye/Dockerfile
@@ -55,6 +55,6 @@ RUN apt-get update \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/App-cpanminus-1.7047* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl5.39.1","-de0"]

--- a/generate.pl
+++ b/generate.pl
@@ -318,6 +318,6 @@ RUN {{docker_slim_run_install}} \
     && rm -fr /root/.cpanm /usr/src/perl /usr/src/{{cpanm_dist_name}}* /tmp/* \
     && cpanm --version && cpm --version
 
-WORKDIR /
+WORKDIR /usr/src/app
 
 CMD ["perl{{version}}","-de0"]


### PR DESCRIPTION
What changed is that in bookworm the lib dir has become a symlink to /usr/lib.
This prevents `COPY . .` to copy over our lib dir to the layer.

For more information:
* https://wiki.debian.org/NewInBookworm
* https://wiki.debian.org/UsrMerge
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=978636:

Closes: https://github.com/Perl/docker-perl/issues/140

Signed-off-by: Wesley Schwengle <waterkip@cpan.org>