### PR TITLE
Remove deprecated set-output from workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,7 @@ jobs:
         name: Enumerate Dockerfiles
         run: |
           matrix="$(dirname */Dockerfile | sort -rn | jq -csR 'rtrimstr("\n") | split("\n") | { directory: . }')"
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
   build-image:
     needs: generate-matrix
     runs-on: ubuntu-latest


### PR DESCRIPTION
For more information:

* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/