### PR TITLE
Source Perl tarballs from MetaCPAN

### DIFF
--- a/5.034.003-main,threaded-bullseye/Dockerfile
+++ b/5.034.003-main,threaded-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-main,threaded-buster/Dockerfile
+++ b/5.034.003-main,threaded-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-main-bullseye/Dockerfile
+++ b/5.034.003-main-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-main-buster/Dockerfile
+++ b/5.034.003-main-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-slim,threaded-bullseye/Dockerfile
+++ b/5.034.003-slim,threaded-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-slim,threaded-buster/Dockerfile
+++ b/5.034.003-slim,threaded-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-slim-bullseye/Dockerfile
+++ b/5.034.003-slim-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.034.003-slim-buster/Dockerfile
+++ b/5.034.003-slim-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.34.3.tar.xz -o perl-5.34.3.tar.xz \
-    && echo '0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1 *perl-5.34.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.34.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.34.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.34.3.tar.gz -o perl-5.34.3.tar.gz \
+    && echo '5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede *perl-5.34.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.34.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.34.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main,threaded-bookworm/Dockerfile
+++ b/5.036.003-main,threaded-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main,threaded-bullseye/Dockerfile
+++ b/5.036.003-main,threaded-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main,threaded-buster/Dockerfile
+++ b/5.036.003-main,threaded-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main-bookworm/Dockerfile
+++ b/5.036.003-main-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main-bullseye/Dockerfile
+++ b/5.036.003-main-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-main-buster/Dockerfile
+++ b/5.036.003-main-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim,threaded-bookworm/Dockerfile
+++ b/5.036.003-slim,threaded-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim,threaded-bullseye/Dockerfile
+++ b/5.036.003-slim,threaded-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim,threaded-buster/Dockerfile
+++ b/5.036.003-slim,threaded-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim-bookworm/Dockerfile
+++ b/5.036.003-slim-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim-bullseye/Dockerfile
+++ b/5.036.003-slim-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.036.003-slim-buster/Dockerfile
+++ b/5.036.003-slim-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.36.3.tar.xz -o perl-5.36.3.tar.xz \
-    && echo '45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd *perl-5.36.3.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.36.3.tar.xz -C /usr/src/perl \
-    && rm perl-5.36.3.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.36.3.tar.gz -o perl-5.36.3.tar.gz \
+    && echo 'f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a *perl-5.36.3.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.36.3.tar.gz -C /usr/src/perl \
+    && rm perl-5.36.3.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main,threaded-bookworm/Dockerfile
+++ b/5.038.002-main,threaded-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main,threaded-bullseye/Dockerfile
+++ b/5.038.002-main,threaded-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main,threaded-buster/Dockerfile
+++ b/5.038.002-main,threaded-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main-bookworm/Dockerfile
+++ b/5.038.002-main-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main-bullseye/Dockerfile
+++ b/5.038.002-main-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-main-buster/Dockerfile
+++ b/5.038.002-main-buster/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:buster
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim,threaded-bookworm/Dockerfile
+++ b/5.038.002-slim,threaded-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim,threaded-bullseye/Dockerfile
+++ b/5.038.002-slim,threaded-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim,threaded-buster/Dockerfile
+++ b/5.038.002-slim,threaded-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim-bookworm/Dockerfile
+++ b/5.038.002-slim-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim-bullseye/Dockerfile
+++ b/5.038.002-slim-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.038.002-slim-buster/Dockerfile
+++ b/5.038.002-slim-buster/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.38.2.tar.xz -o perl-5.38.2.tar.xz \
-    && echo 'd91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8 *perl-5.38.2.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.38.2.tar.xz -C /usr/src/perl \
-    && rm perl-5.38.2.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/P/PE/PEVANS/perl-5.38.2.tar.gz -o perl-5.38.2.tar.gz \
+    && echo 'a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e *perl-5.38.2.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.38.2.tar.gz -C /usr/src/perl \
+    && rm perl-5.38.2.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-main,threaded-bookworm/Dockerfile
+++ b/5.039.005-main,threaded-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-main,threaded-bullseye/Dockerfile
+++ b/5.039.005-main,threaded-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-main-bookworm/Dockerfile
+++ b/5.039.005-main-bookworm/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bookworm
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-main-bullseye/Dockerfile
+++ b/5.039.005-main-bullseye/Dockerfile
@@ -4,10 +4,10 @@ FROM buildpack-deps:bullseye
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-slim,threaded-bookworm/Dockerfile
+++ b/5.039.005-slim,threaded-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-slim,threaded-bullseye/Dockerfile
+++ b/5.039.005-slim,threaded-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-slim-bookworm/Dockerfile
+++ b/5.039.005-slim-bookworm/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/5.039.005-slim-bullseye/Dockerfile
+++ b/5.039.005-slim-bullseye/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.39.5.tar.xz -o perl-5.39.5.tar.xz \
-    && echo '4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930 *perl-5.39.5.tar.xz' | sha256sum --strict --check - \
-    && tar --strip-components=1 -xaf perl-5.39.5.tar.xz -C /usr/src/perl \
-    && rm perl-5.39.5.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/E/ET/ETHER/perl-5.39.5.tar.gz -o perl-5.39.5.tar.gz \
+    && echo '39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1 *perl-5.39.5.tar.gz' | sha256sum --strict --check - \
+    && tar --strip-components=1 -xaf perl-5.39.5.tar.gz -C /usr/src/perl \
+    && rm perl-5.39.5.tar.gz \
     && cat *.patch | patch -p1 \
     && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
     && archBits="$(dpkg-architecture --query DEB_BUILD_ARCH_BITS)" \

--- a/config.yml
+++ b/config.yml
@@ -9,31 +9,27 @@ options:
 
 releases:
   - version: 5.39.5
-    sha256:  4048cf0065f347a03ec85e989631a64e03ba9c9ccbc8f2a35153cad07fe21930
+    sha256:  39e4f8df83cb747edf3e17a0a2f8ee10353ba16729b665cd5047cec2722f6ed1
     extra_flags: "-Dusedevel -Dversiononly=undef"
-    type:    xz
     debian_release:
       - bullseye
       - bookworm
 
   - version: 5.34.3
-    sha256:  0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1
-    type:    xz
+    sha256:  5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede
     debian_release:
       - buster
       - bullseye
 
   - version: 5.36.3
-    sha256:  45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd
-    type:    xz
+    sha256:  f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a
     debian_release:
       - buster
       - bullseye
       - bookworm
 
   - version: 5.38.2
-    sha256:  d91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8
-    type:    xz
+    sha256:  a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e
     debian_release:
       - buster
       - bullseye

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'CPAN::Perl::Releases::MetaCPAN';
 requires 'Devel::PatchPerl';
 requires 'YAML::XS';
 requires 'LWP::Simple';


### PR DESCRIPTION
Take advantage of the the faster indexing in MetaCPAN to get Perl releases (especially devel - this is prep for the 5.39.6 release,) and align with the links as specified in more recent Perl release announcements.

This also removes the tarball release type in `config.yml` as only `tar.gz` download URLs are provided by the MetaCPAN API.