### PR TITLE
eol: fix Perl source links

### DIFF
--- a/eol/5.008.009-main,threaded-buster/Dockerfile
+++ b/eol/5.008.009-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/eol/5.008.009-main-buster/Dockerfile
+++ b/eol/5.008.009-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/eol/5.008.009-slim,threaded-buster/Dockerfile
+++ b/eol/5.008.009-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/eol/5.008.009-slim-buster/Dockerfile
+++ b/eol/5.008.009-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/N/NW/NWCLARK/perl-5.8.9.tar.bz2 -o perl-5.8.9.tar.bz2 \
     && echo '1097fbcd48ceccb2bc735d119c9db399a02a8ab9f7dc53e29e47e6a8d0d72e79 *perl-5.8.9.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.8.9.tar.bz2 -C /usr/src/perl \
     && rm perl-5.8.9.tar.bz2 \

--- a/eol/5.010.001-main,threaded-buster/Dockerfile
+++ b/eol/5.010.001-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/eol/5.010.001-main-buster/Dockerfile
+++ b/eol/5.010.001-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/eol/5.010.001-slim,threaded-buster/Dockerfile
+++ b/eol/5.010.001-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/eol/5.010.001-slim-buster/Dockerfile
+++ b/eol/5.010.001-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.10.1.tar.bz2 -o perl-5.10.1.tar.bz2 \
     && echo '9385f2c8c2ca8b1dc4a7c31903f1f8dc8f2ba867dc2a9e5c93012ed6b564e826 *perl-5.10.1.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.10.1.tar.bz2 -C /usr/src/perl \
     && rm perl-5.10.1.tar.bz2 \

--- a/eol/5.012.005-main,threaded-buster/Dockerfile
+++ b/eol/5.012.005-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/eol/5.012.005-main-buster/Dockerfile
+++ b/eol/5.012.005-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/eol/5.012.005-slim,threaded-buster/Dockerfile
+++ b/eol/5.012.005-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/eol/5.012.005-slim-buster/Dockerfile
+++ b/eol/5.012.005-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DO/DOM/perl-5.12.5.tar.bz2 -o perl-5.12.5.tar.bz2 \
     && echo '10749417fd3010aae320a34181ad4cd6a4855c1fc63403b87fa4d630b18e966c *perl-5.12.5.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.12.5.tar.bz2 -C /usr/src/perl \
     && rm perl-5.12.5.tar.bz2 \

--- a/eol/5.014.004-main,threaded-buster/Dockerfile
+++ b/eol/5.014.004-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/eol/5.014.004-main-buster/Dockerfile
+++ b/eol/5.014.004-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/eol/5.014.004-slim,threaded-buster/Dockerfile
+++ b/eol/5.014.004-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/eol/5.014.004-slim-buster/Dockerfile
+++ b/eol/5.014.004-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/D/DA/DAPM/perl-5.14.4.tar.bz2 -o perl-5.14.4.tar.bz2 \
     && echo 'eece8c2b0d491bf6f746bd1f4f1bb7ce26f6b98e91c54690c617d7af38964745 *perl-5.14.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.14.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.14.4.tar.bz2 \

--- a/eol/5.016.003-main,threaded-buster/Dockerfile
+++ b/eol/5.016.003-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/eol/5.016.003-main-buster/Dockerfile
+++ b/eol/5.016.003-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/eol/5.016.003-slim,threaded-buster/Dockerfile
+++ b/eol/5.016.003-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/eol/5.016.003-slim-buster/Dockerfile
+++ b/eol/5.016.003-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.16.3.tar.bz2 -o perl-5.16.3.tar.bz2 \
     && echo 'bb7bc735e6813b177dcfccd480defcde7eddefa173b5967eac11babd1bfa98e8 *perl-5.16.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.16.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.16.3.tar.bz2 \

--- a/eol/5.018.004-main,threaded-buster/Dockerfile
+++ b/eol/5.018.004-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/eol/5.018.004-main-buster/Dockerfile
+++ b/eol/5.018.004-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/eol/5.018.004-slim,threaded-buster/Dockerfile
+++ b/eol/5.018.004-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/eol/5.018.004-slim-buster/Dockerfile
+++ b/eol/5.018.004-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/R/RJ/RJBS/perl-5.18.4.tar.bz2 -o perl-5.18.4.tar.bz2 \
     && echo '1fb4d27b75cd244e849f253320260efe1750641aaff4a18ce0d67556ff1b96a5 *perl-5.18.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.18.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.18.4.tar.bz2 \

--- a/eol/5.020.003-main,threaded-buster/Dockerfile
+++ b/eol/5.020.003-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/eol/5.020.003-main-buster/Dockerfile
+++ b/eol/5.020.003-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/eol/5.020.003-slim,threaded-buster/Dockerfile
+++ b/eol/5.020.003-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/eol/5.020.003-slim-buster/Dockerfile
+++ b/eol/5.020.003-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.20.3.tar.bz2 -o perl-5.20.3.tar.bz2 \
     && echo '1b40068166c242e34a536836286e70b78410602a80615143301e52aa2901493b *perl-5.20.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.20.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.20.3.tar.bz2 \

--- a/eol/5.022.004-main,threaded-buster/Dockerfile
+++ b/eol/5.022.004-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/eol/5.022.004-main-buster/Dockerfile
+++ b/eol/5.022.004-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/eol/5.022.004-slim,threaded-buster/Dockerfile
+++ b/eol/5.022.004-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/eol/5.022.004-slim-buster/Dockerfile
+++ b/eol/5.022.004-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.22.4.tar.bz2 -o perl-5.22.4.tar.bz2 \
     && echo '8b3122046d1186598082d0e6da53193b045e85e3505e7d37ee0bdd0bdb539b71 *perl-5.22.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.22.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.22.4.tar.bz2 \

--- a/eol/5.024.004-main,threaded-buster/Dockerfile
+++ b/eol/5.024.004-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/eol/5.024.004-main-buster/Dockerfile
+++ b/eol/5.024.004-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/eol/5.024.004-slim,threaded-buster/Dockerfile
+++ b/eol/5.024.004-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/eol/5.024.004-slim-buster/Dockerfile
+++ b/eol/5.024.004-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.24.4.tar.bz2 -o perl-5.24.4.tar.bz2 \
     && echo 'e34ff38c54857f431f37403b757267c9998152bf46b5c750b462f62461279b10 *perl-5.24.4.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.24.4.tar.bz2 -C /usr/src/perl \
     && rm perl-5.24.4.tar.bz2 \

--- a/eol/5.026.003-main,threaded-buster/Dockerfile
+++ b/eol/5.026.003-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
     && echo '9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477 *perl-5.26.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.3.tar.bz2 \

--- a/eol/5.026.003-main-buster/Dockerfile
+++ b/eol/5.026.003-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
     && echo '9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477 *perl-5.26.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.3.tar.bz2 \

--- a/eol/5.026.003-slim,threaded-buster/Dockerfile
+++ b/eol/5.026.003-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
     && echo '9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477 *perl-5.26.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.3.tar.bz2 \

--- a/eol/5.026.003-slim-buster/Dockerfile
+++ b/eol/5.026.003-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
+    && curl -SL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.26.3.tar.bz2 -o perl-5.26.3.tar.bz2 \
     && echo '9ff35a613213f29ab53975141af6825ae7d4408895538cac0922e47ab92a1477 *perl-5.26.3.tar.bz2' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.26.3.tar.bz2 -C /usr/src/perl \
     && rm perl-5.26.3.tar.bz2 \

--- a/eol/5.028.003-main,threaded-buster/Dockerfile
+++ b/eol/5.028.003-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
     && echo '77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5 *perl-5.28.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.3.tar.xz -C /usr/src/perl \
     && rm perl-5.28.3.tar.xz \

--- a/eol/5.028.003-main-buster/Dockerfile
+++ b/eol/5.028.003-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
     && echo '77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5 *perl-5.28.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.3.tar.xz -C /usr/src/perl \
     && rm perl-5.28.3.tar.xz \

--- a/eol/5.028.003-slim,threaded-buster/Dockerfile
+++ b/eol/5.028.003-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
     && echo '77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5 *perl-5.28.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.3.tar.xz -C /usr/src/perl \
     && rm perl-5.28.3.tar.xz \

--- a/eol/5.028.003-slim-buster/Dockerfile
+++ b/eol/5.028.003-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.3.tar.xz -o perl-5.28.3.tar.xz \
     && echo '77dc1ddf541643af14d585867d3d0741cce45d0dbe8f1467024e63165d9e2fc5 *perl-5.28.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.28.3.tar.xz -C /usr/src/perl \
     && rm perl-5.28.3.tar.xz \

--- a/eol/5.030.003-main,threaded-bullseye/Dockerfile
+++ b/eol/5.030.003-main,threaded-bullseye/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-main,threaded-buster/Dockerfile
+++ b/eol/5.030.003-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-main-bullseye/Dockerfile
+++ b/eol/5.030.003-main-bullseye/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-main-buster/Dockerfile
+++ b/eol/5.030.003-main-buster/Dockerfile
@@ -5,7 +5,7 @@ COPY *.patch /usr/src/perl/
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-slim,threaded-bullseye/Dockerfile
+++ b/eol/5.030.003-slim,threaded-bullseye/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-slim,threaded-buster/Dockerfile
+++ b/eol/5.030.003-slim,threaded-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-slim-bullseye/Dockerfile
+++ b/eol/5.030.003-slim-bullseye/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.030.003-slim-buster/Dockerfile
+++ b/eol/5.030.003-slim-buster/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        # procps \
        # zlib1g-dev \
        xz-utils \
-    && curl -SL https://www.cpan.org/src/5.0/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
+    && curl -SL https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.30.3.tar.xz -o perl-5.30.3.tar.xz \
     && echo '6967595f2e3f3a94544c35152f9a25e0cb8ea24ae45f4bf1882f2e33f4a400f4 *perl-5.30.3.tar.xz' | sha256sum -c - \
     && tar --strip-components=1 -xaf perl-5.30.3.tar.xz -C /usr/src/perl \
     && rm perl-5.30.3.tar.xz \

--- a/eol/5.032.001-main,threaded-bullseye/Dockerfile
+++ b/eol/5.032.001-main,threaded-bullseye/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-main,threaded-buster/Dockerfile
+++ b/eol/5.032.001-main,threaded-buster/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-main-bullseye/Dockerfile
+++ b/eol/5.032.001-main-bullseye/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-main-buster/Dockerfile
+++ b/eol/5.032.001-main-buster/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Peter Martini <PeterCMartini@GMail.com>, Zak B. Elep <zakame@c
 WORKDIR /usr/src/perl
 
 RUN true \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-slim,threaded-bullseye/Dockerfile
+++ b/eol/5.032.001-slim,threaded-bullseye/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-slim,threaded-buster/Dockerfile
+++ b/eol/5.032.001-slim,threaded-buster/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-slim-bullseye/Dockerfile
+++ b/eol/5.032.001-slim-bullseye/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \

--- a/eol/5.032.001-slim-buster/Dockerfile
+++ b/eol/5.032.001-slim-buster/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
        zlib1g-dev \
        xz-utils \
        libssl-dev \
-    && curl -fL https://www.cpan.org/src/5.0/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
+    && curl -fL https://cpan.metacpan.org/authors/id/S/SH/SHAY/perl-5.32.1.tar.xz -o perl-5.32.1.tar.xz \
     && echo '57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309 *perl-5.32.1.tar.xz' | sha256sum --strict --check - \
     && tar --strip-components=1 -xaf perl-5.32.1.tar.xz -C /usr/src/perl \
     && rm perl-5.32.1.tar.xz \


### PR DESCRIPTION
https://www.cpan.org/src/5.0/ is no longer a reliable source of Perl source
tarballs - use MetaCPAN instead.

Ref #161