### PR TITLE
[CVE-2024-45321] generate: hotpatch bin/cpanm to use HTTPS endpoints

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,11 +62,15 @@ jobs:
         run: |
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
+          docker run "$img" cpanm -v Plack@0.9990
+          docker run "$img" cpanm -v Crypt::Argon2@0.024
           docker run "$img" cpanm -v Mojolicious
       - name: Run cpm install test
         run: |
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
+          docker run "$img" cpm install -v Plack@0.9990
+          docker run "$img" cpm install -v Crypt::Argon2@0.024
           docker run "$img" cpm install -v Mojolicious
       - name: COPY all to default WORKDIR
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -64,7 +64,7 @@ jobs:
           img="perl:${dir//,/-}"
           if [[ "$dir" != *"slim"* ]]; then
             docker run "$img" cpanm -v Try::Tiny@0.30
-            docker run "$img" cpanm -v Crypt::Argon2@0.024
+            docker run "$img" cpanm -v Net::DNS@1.45_02
           fi
           docker run "$img" cpanm -v Mojolicious
       - name: Run cpm install test
@@ -73,7 +73,7 @@ jobs:
           img="perl:${dir//,/-}"
           if [[ "$dir" != *"slim"* ]]; then
             docker run "$img" cpm install -v Try::Tiny@0.30
-            docker run "$img" cpm install -v Crypt::Argon2@0.024
+            docker run "$img" cpm install -v Net::DNS@1.45_02
           fi
           docker run "$img" cpm install -v Mojolicious
       - name: COPY all to default WORKDIR

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -63,7 +63,7 @@ jobs:
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           if [[ "$dir" != *"slim"* ]]; then
-            docker run "$img" cpanm -v Plack@0.9990
+            docker run "$img" cpanm -v Try::Tiny@0.30
             docker run "$img" cpanm -v Crypt::Argon2@0.024
           fi
           docker run "$img" cpanm -v Mojolicious
@@ -72,7 +72,7 @@ jobs:
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
           if [[ "$dir" != *"slim"* ]]; then
-            docker run "$img" cpm install -v Plack@0.9990
+            docker run "$img" cpm install -v Try::Tiny@0.30
             docker run "$img" cpm install -v Crypt::Argon2@0.024
           fi
           docker run "$img" cpm install -v Mojolicious

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,15 +62,19 @@ jobs:
         run: |
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
-          docker run "$img" cpanm -v Plack@0.9990
-          docker run "$img" cpanm -v Crypt::Argon2@0.024
+          if [[ "$dir" != *"slim"* ]]; then
+            docker run "$img" cpanm -v Plack@0.9990
+            docker run "$img" cpanm -v Crypt::Argon2@0.024
+          fi
           docker run "$img" cpanm -v Mojolicious
       - name: Run cpm install test
         run: |
           dir='${{ matrix.directory }}'
           img="perl:${dir//,/-}"
-          docker run "$img" cpm install -v Plack@0.9990
-          docker run "$img" cpm install -v Crypt::Argon2@0.024
+          if [[ "$dir" != *"slim"* ]]; then
+            docker run "$img" cpm install -v Plack@0.9990
+            docker run "$img" cpm install -v Crypt::Argon2@0.024
+          fi
           docker run "$img" cpm install -v Mojolicious
       - name: COPY all to default WORKDIR
         run: |

--- a/generate.pl
+++ b/generate.pl
@@ -91,6 +91,7 @@ my %install_modules = (
     url    => "https://www.cpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7047.tar.gz",
     # sha256 taken from http://www.cpan.org/authors/id/M/MI/MIYAGAWA/CHECKSUMS
     sha256 => "963e63c6e1a8725ff2f624e9086396ae150db51dd0a337c3781d09a994af05a5",
+    patch  => q[perl -pi -E 's{http://(www\.cpan\.org|backpan\.perl\.org|cpan\.metacpan\.org|fastapi\.metacpan\.org|cpanmetadb\.plackperl\.org)}{https://$1}g' bin/cpanm],
   },
   iosocketssl => {
     name   => "IO-Socket-SSL-2.085",
@@ -325,7 +326,9 @@ RUN {{docker_slim_run_install}} \
     && cd /usr/src \
     && curl -fLO {{cpanm_dist_url}} \
     && echo '{{cpanm_dist_sha256}} *{{cpanm_dist_name}}.tar.gz' | sha256sum --strict --check - \
-    && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} && perl bin/cpanm . && cd /root \
+    && tar -xzf {{cpanm_dist_name}}.tar.gz && cd {{cpanm_dist_name}} \
+    && {{cpanm_dist_patch}} \
+    && perl bin/cpanm . && cd /root \
     && curl -fLO '{{netssleay_dist_url}}' \
     && echo '{{netssleay_dist_sha256}} *{{netssleay_dist_name}}.tar.gz' | sha256sum --strict --check - \
     && cpanm --from $PWD {{netssleay_dist_name}}.tar.gz \


### PR DESCRIPTION
This commit patches out insecure http endpoints from the fatpacked `bin/cpanm` executable

Tested with:
- `cpanm Plack@0.9990` (backpan)
- `cpanm Crypt::Argon2@0.024` (TRIAL)
- `cpanm Mojolicious`

Cc: @zakame @dgl @garu 