### PR TITLE
Build development release on trixie/sid for Debian

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,8 @@ releases:
     debian_release:
       - bullseye
       - bookworm
+      - trixie
+      - sid
 
   - version: 5.36.3
     sha256:  f2a1ad88116391a176262dd42dfc52ef22afb40f4c0e9810f15d561e6f1c726a


### PR DESCRIPTION
This could potentially uncover issues because sid and by extension trixie are development releases of the Debian project. They for example undergo t64 migrations, get newer compilers and this potentially uncovers more information when running development releases. For example, see gcc:

apt-cache policy gcc
gcc:
  Installed: 4:14.1.0-2
  Candidate: 4:14.1.0-2
  Version table:
 *** 4:14.1.0-2 900
        900 https://deb.debian.org/debian unstable/main amd64 Packages
        500 https://deb.debian.org/debian testing/main amd64 Packages
        100 /var/lib/dpkg/status
     4:12.2.0-3 10
         10 https://deb.debian.org/debian stable/main amd64 Packages
     4:10.2.1-1 10
         10 https://deb.debian.org/debian oldstable/main amd64 Packages
     4:8.3.0-1 10
         10 https://deb.debian.org/debian oldoldstable/main amd64 Packages