### PR TITLE
library.pl: drop mips64le, add riscv64 for trixie

### DIFF
--- a/library.pl
+++ b/library.pl
@@ -8,7 +8,7 @@ use YAML::XS;
 my %arches = (
 
   # https://github.com/docker-library/official-images/blob/master/library/debian
-  default  => 'amd64, arm32v5, arm32v7, arm64v8, mips64le, ppc64le, s390x',
+  default  => 'amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x',
   bookworm => 'amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x',
   bullseye => 'amd64, arm32v7, arm64v8, i386',
   buster   => 'amd64, arm32v7, arm64v8, i386',


### PR DESCRIPTION
mips64le no longer listed in https://www.debian.org/News/2025/20250809